### PR TITLE
Feature/layout manager

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -34,6 +34,9 @@ rules:
       exceptions:
       # Lodash gets a single character, why not Ramda?
       - R
+      # x/y coordinates, because I'm lazy.
+      - x
+      - y
 
   space-before-function-paren:
     - error

--- a/App.js
+++ b/App.js
@@ -7,6 +7,7 @@ import LayoutManager from './src/components/LayoutManager';
 import LayoutConfig from './src/components/LayoutConfig';
 import ServerLink from './src/components/ServerLink';
 import * as colors from './src/constants/colors';
+import Loading from './src/components/Loading';
 import Groups from './src/components/Groups';
 import store from './src/redux-store';
 
@@ -27,10 +28,11 @@ const Routes = StackNavigator(
     LayoutManager: { screen: LayoutManager, navigationOptions },
     LayoutConfig: { screen: LayoutConfig, navigationOptions },
     ServerLink: { screen: ServerLink, navigationOptions },
+    Loading: { screen: Loading, navigationOptions },
     Groups: { screen: Groups, navigationOptions },
   },
   {
-    initialRouteName: 'LayoutManager',
+    initialRouteName: 'Loading',
     cardStyle: {
       backgroundColor: colors.appBackground,
     },

--- a/App.js
+++ b/App.js
@@ -2,7 +2,7 @@ import { View, StatusBar, StyleSheet } from 'react-native';
 import { Provider } from 'react-redux';
 import React from 'react';
 
-import ServerLink from './src/components/ServerLink';
+import LayoutManager from './src/components/LayoutManager';
 import * as colors from './src/constants/colors';
 import store from './src/redux-store';
 
@@ -19,7 +19,7 @@ export default class App extends React.Component {
       <Provider store={store}>
         <View style={styles.container}>
           <StatusBar hidden />
-          <ServerLink />
+          <LayoutManager />
         </View>
       </Provider>
     );

--- a/App.js
+++ b/App.js
@@ -4,6 +4,7 @@ import { Provider } from 'react-redux';
 import React from 'react';
 
 import LayoutManager from './src/components/LayoutManager';
+import LayoutConfig from './src/components/LayoutConfig';
 import ServerLink from './src/components/ServerLink';
 import * as colors from './src/constants/colors';
 import Groups from './src/components/Groups';
@@ -16,17 +17,15 @@ const styles = StyleSheet.create({
 });
 
 const navigationOptions = {
-  headerStyle: {
-    backgroundColor: colors.navbar.bg,
-  },
-  headerTitleStyle: {
-    color: colors.navbar.text,
-  },
+  headerStyle: { backgroundColor: colors.navbar.bg },
+  headerTitleStyle: { color: colors.navbar.text },
+  headerTintColor: colors.navbar.text,
 };
 
 const Routes = StackNavigator(
   {
     LayoutManager: { screen: LayoutManager, navigationOptions },
+    LayoutConfig: { screen: LayoutConfig, navigationOptions },
     ServerLink: { screen: ServerLink, navigationOptions },
     Groups: { screen: Groups, navigationOptions },
   },

--- a/App.js
+++ b/App.js
@@ -1,17 +1,42 @@
 import { View, StatusBar, StyleSheet } from 'react-native';
+import { StackNavigator } from 'react-navigation';
 import { Provider } from 'react-redux';
 import React from 'react';
 
 import LayoutManager from './src/components/LayoutManager';
+import ServerLink from './src/components/ServerLink';
 import * as colors from './src/constants/colors';
+import Groups from './src/components/Groups';
 import store from './src/redux-store';
 
 const styles = StyleSheet.create({
   container: {
-    backgroundColor: colors.appBackground,
-    height: '100%',
+    minHeight: '100%',
   },
 });
+
+const navigationOptions = {
+  headerStyle: {
+    backgroundColor: colors.navbar.bg,
+  },
+  headerTitleStyle: {
+    color: colors.navbar.text,
+  },
+};
+
+const Routes = StackNavigator(
+  {
+    LayoutManager: { screen: LayoutManager, navigationOptions },
+    ServerLink: { screen: ServerLink, navigationOptions },
+    Groups: { screen: Groups, navigationOptions },
+  },
+  {
+    initialRouteName: 'LayoutManager',
+    cardStyle: {
+      backgroundColor: colors.appBackground,
+    },
+  },
+);
 
 export default class App extends React.Component {
   render() {
@@ -19,7 +44,7 @@ export default class App extends React.Component {
       <Provider store={store}>
         <View style={styles.container}>
           <StatusBar hidden />
-          <LayoutManager />
+          <Routes />
         </View>
       </Provider>
     );

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "redux-actions": "^2.2.1",
     "redux-promise": "^0.5.3",
     "redux-thunk": "^2.2.0",
-    "reselect": "^3.0.1"
+    "reselect": "^3.0.1",
+    "styled-components": "^2.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "ramda": "^0.25.0",
     "react": "16.2.0",
     "react-native": "^0.51.0",
+    "react-navigation": "^1.0.0-beta.23",
     "react-redux": "^5.0.6",
     "redux": "^3.7.2",
     "redux-actions": "^2.2.1",

--- a/src/actions/__tests__/filament.test.js
+++ b/src/actions/__tests__/filament.test.js
@@ -86,5 +86,12 @@ describe('Filament', () => {
       const action = actions.pingServer('http://filament/')(dispatch);
       await expect(action.payload).rejects.toEqual(expect.any(Error));
     });
+
+    it('resolves truthy if the ping was a success', async () => {
+      const action = actions.pingServer('http://filament/')(dispatch);
+      const result = await action.payload;
+
+      expect(result).toEqual({ success: true });
+    });
   });
 });

--- a/src/actions/__tests__/layout.test.js
+++ b/src/actions/__tests__/layout.test.js
@@ -1,0 +1,52 @@
+import { AsyncStorage } from 'react-native';
+import R from 'ramda';
+
+import * as actions from '../layout';
+
+jest.spyOn(AsyncStorage, 'getItem');
+jest.spyOn(AsyncStorage, 'setItem');
+
+describe('Layout', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    const response = Promise.resolve(null);
+
+    AsyncStorage.getItem.mockReturnValue(response);
+    AsyncStorage.setItem.mockReturnValue(response);
+  });
+
+  describe('persistLayouts', () => {
+    const dispatch = jest.fn(R.identity);
+
+    it('saves the layouts to disk', async () => {
+      const reserved = {
+        '1:1': { x: 1, y: 1, width: 1, height: 1, group: '5' },
+      };
+
+      const getState = jest.fn().mockReturnValue({ layout: { reserved } });
+      const result = actions.persistLayouts()(dispatch, getState);
+
+      expect(dispatch).toHaveBeenCalled();
+      expect(result.payload).toEqual(expect.any(Promise));
+      await result.payload;
+
+      expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+        expect.any(String),
+        reserved,
+      );
+    });
+
+    it('rejects if the save fails', async () => {
+      const error = new Error('Testing layout persist failure');
+      const failure = Promise.reject(error);
+      AsyncStorage.setItem.mockReturnValue(failure);
+
+      const layout = { reserved: {} };
+      const getState = jest.fn().mockReturnValue({ layout });
+      const result = actions.persistLayouts()(dispatch, getState);
+
+      await expect(result.payload).rejects.toBe(error);
+    });
+  });
+});

--- a/src/actions/__tests__/layout.test.js
+++ b/src/actions/__tests__/layout.test.js
@@ -32,8 +32,8 @@ describe('Layout', () => {
       await result.payload;
 
       expect(AsyncStorage.setItem).toHaveBeenCalledWith(
-        expect.any(String),
-        reserved,
+        actions.LAYOUT_STORAGE_KEY,
+        JSON.stringify(reserved),
       );
     });
 
@@ -47,6 +47,34 @@ describe('Layout', () => {
       const result = actions.persistLayouts()(dispatch, getState);
 
       await expect(result.payload).rejects.toBe(error);
+    });
+  });
+
+  describe('getLayouts', () => {
+    it('loads all layouts', async () => {
+      const action = actions.getLayouts();
+
+      expect(action.payload).toEqual(expect.any(Promise));
+      const result = await action.payload;
+
+      expect(result).toBe(null);
+      expect(AsyncStorage.getItem).toHaveBeenCalledWith(
+        actions.LAYOUT_STORAGE_KEY,
+      );
+    });
+
+    it('parses the result if it exists', async () => {
+      const reserved = {
+        '1:1': { x: 1, y: 1, width: 1, height: 1, group: '5' },
+      };
+
+      const response = Promise.resolve(JSON.stringify(reserved));
+      AsyncStorage.getItem.mockReturnValue(response);
+
+      const action = actions.getLayouts();
+      const result = await action.payload;
+
+      expect(result).toEqual(reserved);
     });
   });
 });

--- a/src/actions/filament.js
+++ b/src/actions/filament.js
@@ -20,6 +20,8 @@ export const pingServer = optimistic('PING_SERVER', async server => {
   assert(data && data.app === 'filament', 'Ping failed, bad server response.');
 
   await AsyncStorage.setItem(SERVER_URL_STORAGE_KEY, parsed.href);
+
+  return { success: true };
 });
 
 export const updateServerUrl = createAction('UPDATE_SERVER_URL');

--- a/src/actions/layout.js
+++ b/src/actions/layout.js
@@ -5,4 +5,6 @@ const createAction = prefixActions('LAYOUT');
 export const setDragActiveState = createAction('SET_DRAG_ACTIVE_STATE');
 export const createCellGroup = createAction('CREATE_CELL_GROUP');
 export const selectGroup = createAction('SELECT_LIGHT_GROUP');
+export const setGroupHover = createAction('SELECT_GROUPING');
 export const createGrouping = createAction('CREATE_GROUPING');
+export const editCellGroup = createAction('EDIT_GROUPING');

--- a/src/actions/layout.js
+++ b/src/actions/layout.js
@@ -1,3 +1,5 @@
+import { AsyncStorage } from 'react-native';
+
 import { prefixActions } from '../utils/actions';
 
 const createAction = prefixActions('LAYOUT');
@@ -10,3 +12,13 @@ export const createGrouping = createAction('CREATE_GROUPING');
 export const deleteGrouping = createAction('DELETE_GROUPING');
 export const updateGrouping = createAction('UPDATE_GROUPING');
 export const editCellGroup = createAction('EDIT_GROUPING');
+
+const LAYOUT_STORAGE_KEY = 'groups_layout';
+export const persistLayouts = () => (dispatch, getState) => {
+  const layouts = getState().layout.reserved;
+
+  const persist = () => AsyncStorage.setItem(LAYOUT_STORAGE_KEY, layouts);
+  const action = createAction('PERSIST', persist);
+
+  return dispatch(action());
+};

--- a/src/actions/layout.js
+++ b/src/actions/layout.js
@@ -7,4 +7,5 @@ export const createCellGroup = createAction('CREATE_CELL_GROUP');
 export const selectGroup = createAction('SELECT_LIGHT_GROUP');
 export const setGroupHover = createAction('SELECT_GROUPING');
 export const createGrouping = createAction('CREATE_GROUPING');
+export const updateGrouping = createAction('UPDATE_GROUPING');
 export const editCellGroup = createAction('EDIT_GROUPING');

--- a/src/actions/layout.js
+++ b/src/actions/layout.js
@@ -13,12 +13,20 @@ export const deleteGrouping = createAction('DELETE_GROUPING');
 export const updateGrouping = createAction('UPDATE_GROUPING');
 export const editCellGroup = createAction('EDIT_GROUPING');
 
-const LAYOUT_STORAGE_KEY = 'groups_layout';
+export const LAYOUT_STORAGE_KEY = 'groups_layout';
 export const persistLayouts = () => (dispatch, getState) => {
-  const layouts = getState().layout.reserved;
+  const layouts = JSON.stringify(getState().layout.reserved);
 
   const persist = () => AsyncStorage.setItem(LAYOUT_STORAGE_KEY, layouts);
   const action = createAction('PERSIST', persist);
 
   return dispatch(action());
 };
+
+export const getLayouts = createAction('GET_LAYOUTS', () =>
+  AsyncStorage.getItem(LAYOUT_STORAGE_KEY).then(layouts => {
+    if (!layouts) return layouts;
+
+    return JSON.parse(layouts);
+  }),
+);

--- a/src/actions/layout.js
+++ b/src/actions/layout.js
@@ -7,5 +7,6 @@ export const createCellGroup = createAction('CREATE_CELL_GROUP');
 export const selectGroup = createAction('SELECT_LIGHT_GROUP');
 export const setGroupHover = createAction('SELECT_GROUPING');
 export const createGrouping = createAction('CREATE_GROUPING');
+export const deleteGrouping = createAction('DELETE_GROUPING');
 export const updateGrouping = createAction('UPDATE_GROUPING');
 export const editCellGroup = createAction('EDIT_GROUPING');

--- a/src/actions/layout.js
+++ b/src/actions/layout.js
@@ -4,3 +4,5 @@ const createAction = prefixActions('LAYOUT');
 
 export const setDragActiveState = createAction('SET_DRAG_ACTIVE_STATE');
 export const createCellGroup = createAction('CREATE_CELL_GROUP');
+export const selectGroup = createAction('SELECT_LIGHT_GROUP');
+export const createGrouping = createAction('CREATE_GROUPING');

--- a/src/actions/layout.js
+++ b/src/actions/layout.js
@@ -3,3 +3,4 @@ import { prefixActions } from '../utils/actions';
 const createAction = prefixActions('LAYOUT');
 
 export const setDragActiveState = createAction('SET_DRAG_ACTIVE_STATE');
+export const createCellGroup = createAction('CREATE_CELL_GROUP');

--- a/src/actions/layout.js
+++ b/src/actions/layout.js
@@ -1,0 +1,5 @@
+import { prefixActions } from '../utils/actions';
+
+const createAction = prefixActions('LAYOUT');
+
+export const setDragActiveState = createAction('SET_DRAG_ACTIVE_STATE');

--- a/src/components/Group.js
+++ b/src/components/Group.js
@@ -15,11 +15,15 @@ export const Container = styled.View`
   justify-content: center;
   align-items: center;
   position: absolute;
-  border-width: 1px;
-  border-bottom-width: 2px;
+  border-width: 0.5px;
 
-  border-bottom-color: ${props =>
-    props.on ? colors.groups.status.on : colors.groups.status.off};
+  ${props =>
+    props.on &&
+    `
+    border-bottom-color: ${colors.groups.status.on};
+    border-bottom-width: 2px;
+    padding-top: 1.5px;
+  `};
 `;
 
 export const Title = styled.Text`
@@ -40,18 +44,19 @@ export class Group extends Component {
       name: PropTypes.string.isRequired,
       id: PropTypes.string.isRequired,
       anyOn: PropTypes.bool,
-    }).isRequired,
+    }),
   };
 
   render() {
     const { group, blockWidth } = this.props;
     const constrainWidth = blockWidth === 1;
     const position = extractLayout(this.props);
+    const on = R.propOr(false, 'anyOn', group);
 
     return (
       <TouchableWithoutFeedback onPress={this.toggleLights}>
-        <Container on={group.anyOn} style={position}>
-          <Title small={constrainWidth}>{this.props.group.name}</Title>
+        <Container on={on} style={position}>
+          <Title small={constrainWidth}>{R.prop('name', group)}</Title>
         </Container>
       </TouchableWithoutFeedback>
     );

--- a/src/components/Group.js
+++ b/src/components/Group.js
@@ -12,17 +12,21 @@ export const styles = StyleSheet.create({
   container: {
     borderColor: colors.groups.divider,
     backgroundColor: colors.groups.bg,
+    justifyContent: 'center',
+    alignItems: 'center',
     position: 'absolute',
-    borderWidth: 1,
     borderBottomWidth: 2,
+    borderWidth: 1,
   },
 
   title: {
     color: colors.text,
     fontSize: 20,
-    padding: 30,
-    width: '100%',
-    textAlign: 'center',
+    padding: 2,
+  },
+
+  smallTitle: {
+    fontSize: 12,
   },
 
   off: { borderBottomColor: colors.groups.status.off },
@@ -33,6 +37,7 @@ const extractLayout = R.pick(['top', 'left', 'width', 'height']);
 export class Group extends Component {
   static propTypes = {
     toggleLights: PropTypes.func.isRequired,
+    blockWidth: PropTypes.number.isRequired,
     serverUrl: PropTypes.string.isRequired,
     group: PropTypes.shape({
       name: PropTypes.string.isRequired,
@@ -42,9 +47,9 @@ export class Group extends Component {
   };
 
   render() {
-    const { group } = this.props;
+    const { group, blockWidth } = this.props;
     const online = group.anyOn ? styles.on : styles.off;
-    const style = [styles.title];
+    const style = [styles.title, blockWidth === 1 && styles.smallTitle];
 
     return (
       <TouchableWithoutFeedback onPress={this.toggleLights}>
@@ -65,10 +70,14 @@ export class Group extends Component {
   };
 }
 
+const withLayout = fn => (state, props) =>
+  R.pipe(R.path(['layout', 'reserved', props.id]), fn)(state);
+
 export const mapStateToProps = selector({
+  blockWidth: withLayout(R.prop('width')),
   serverUrl: R.path(['server', 'url']),
   group: (state, props) => {
-    const groupId = R.path(['layout', 'reserved', props.id, 'group'], state);
+    const groupId = withLayout(R.prop('group'))(state, props);
 
     return R.path(['groups', groupId], state);
   },

--- a/src/components/Group.js
+++ b/src/components/Group.js
@@ -1,37 +1,34 @@
+import { TouchableWithoutFeedback } from 'react-native';
+import styled from 'styled-components/native';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import R from 'ramda';
-import { TouchableWithoutFeedback, StyleSheet, Text, View } from 'react-native';
 
 import * as colors from '../constants/colors';
 import * as actions from '../actions/groups';
 import { selector } from '../utils/redux';
 
-export const styles = StyleSheet.create({
-  container: {
-    borderColor: colors.groups.divider,
-    backgroundColor: colors.groups.bg,
-    justifyContent: 'center',
-    alignItems: 'center',
-    position: 'absolute',
-    borderBottomWidth: 2,
-    borderWidth: 1,
-  },
+export const Container = styled.View`
+  border-color: ${colors.groups.divider};
+  background-color: ${colors.groups.bg};
+  justify-content: center;
+  align-items: center;
+  position: absolute;
+  border-width: 1px;
+  border-bottom-width: 2px;
 
-  title: {
-    color: colors.text,
-    fontSize: 20,
-    padding: 2,
-  },
+  border-bottom-color: ${props =>
+    props.on ? colors.groups.status.on : colors.groups.status.off};
+`;
 
-  smallTitle: {
-    fontSize: 12,
-  },
+export const Title = styled.Text`
+  color: ${colors.text};
+  font-size: 20px;
+  padding: 2px;
 
-  off: { borderBottomColor: colors.groups.status.off },
-  on: { borderBottomColor: colors.groups.status.on },
-});
+  ${props => props.small && 'font-size: 12px'};
+`;
 
 const extractLayout = R.pick(['top', 'left', 'width', 'height']);
 export class Group extends Component {
@@ -48,14 +45,14 @@ export class Group extends Component {
 
   render() {
     const { group, blockWidth } = this.props;
-    const online = group.anyOn ? styles.on : styles.off;
-    const style = [styles.title, blockWidth === 1 && styles.smallTitle];
+    const constrainWidth = blockWidth === 1;
+    const position = extractLayout(this.props);
 
     return (
       <TouchableWithoutFeedback onPress={this.toggleLights}>
-        <View style={[styles.container, online, extractLayout(this.props)]}>
-          <Text style={style}>{this.props.group.name}</Text>
-        </View>
+        <Container on={group.anyOn} style={position}>
+          <Title small={constrainWidth}>{this.props.group.name}</Title>
+        </Container>
       </TouchableWithoutFeedback>
     );
   }

--- a/src/components/Group.js
+++ b/src/components/Group.js
@@ -10,8 +10,11 @@ import { selector } from '../utils/redux';
 
 export const styles = StyleSheet.create({
   container: {
+    borderColor: colors.groups.divider,
     backgroundColor: colors.groups.bg,
-    width: '50%',
+    position: 'absolute',
+    borderWidth: 1,
+    borderBottomWidth: 2,
   },
 
   title: {
@@ -22,25 +25,15 @@ export const styles = StyleSheet.create({
     textAlign: 'center',
   },
 
-  divide: {
-    borderRightWidth: 2,
-    borderColor: colors.groups.divider,
-  },
-
-  status: {
-    height: 2,
-    width: '100%',
-  },
-
-  off: { backgroundColor: colors.groups.status.off },
-  on: { backgroundColor: colors.groups.status.on },
+  off: { borderBottomColor: colors.groups.status.off },
+  on: { borderBottomColor: colors.groups.status.on },
 });
 
+const extractLayout = R.pick(['top', 'left', 'width', 'height']);
 export class Group extends Component {
   static propTypes = {
     toggleLights: PropTypes.func.isRequired,
     serverUrl: PropTypes.string.isRequired,
-    divide: PropTypes.bool,
     group: PropTypes.shape({
       name: PropTypes.string.isRequired,
       id: PropTypes.string.isRequired,
@@ -49,20 +42,14 @@ export class Group extends Component {
   };
 
   render() {
-    const { group, divide } = this.props;
+    const { group } = this.props;
     const online = group.anyOn ? styles.on : styles.off;
     const style = [styles.title];
 
-    if (divide) {
-      style.push(styles.divide);
-    }
-
     return (
       <TouchableWithoutFeedback onPress={this.toggleLights}>
-        <View style={styles.container}>
+        <View style={[styles.container, online, extractLayout(this.props)]}>
           <Text style={style}>{this.props.group.name}</Text>
-
-          <View style={[styles.status, online]} />
         </View>
       </TouchableWithoutFeedback>
     );
@@ -79,8 +66,12 @@ export class Group extends Component {
 }
 
 export const mapStateToProps = selector({
-  group: (state, props) => R.path(['groups', props.id], state),
   serverUrl: R.path(['server', 'url']),
+  group: (state, props) => {
+    const groupId = R.path(['layout', 'reserved', props.id, 'group'], state);
+
+    return R.path(['groups', groupId], state);
+  },
 });
 
 const mapDispatchToProps = {

--- a/src/components/Group.js
+++ b/src/components/Group.js
@@ -6,6 +6,7 @@ import { TouchableWithoutFeedback, StyleSheet, Text, View } from 'react-native';
 
 import * as colors from '../constants/colors';
 import * as actions from '../actions/groups';
+import { selector } from '../utils/redux';
 
 export const styles = StyleSheet.create({
   container: {
@@ -77,9 +78,9 @@ export class Group extends Component {
   };
 }
 
-export const mapStateToProps = (state, props) => ({
-  serverUrl: R.path(['server', 'url'], state),
-  group: R.path(['groups', props.id], state),
+export const mapStateToProps = selector({
+  group: (state, props) => R.path(['groups', props.id], state),
+  serverUrl: R.path(['server', 'url']),
 });
 
 const mapDispatchToProps = {

--- a/src/components/Groups.js
+++ b/src/components/Groups.js
@@ -1,4 +1,5 @@
-import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { TouchableOpacity } from 'react-native';
+import styled from 'styled-components/native';
 import { createSelector } from 'reselect';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
@@ -11,20 +12,18 @@ import { selector } from '../utils/redux';
 import Layout from './Layout';
 import Group from './Group';
 
-export const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
+const Container = styled.View`
+  flex: 1;
+`;
 
-  editButtonContainer: {
-    marginRight: 16,
-  },
+const EditButtonContainer = styled.View`
+  margin-right: 16px;
+`;
 
-  editButton: {
-    color: colors.navbar.text,
-    fontSize: 18,
-  },
-});
+const EditLayout = styled.Text`
+  color: ${colors.navbar.text};
+  font-size: 18px;
+`;
 
 const renderEmptySpace = R.always(null);
 
@@ -42,9 +41,9 @@ export class Groups extends Component {
         title="Edit"
         onPress={() => props.navigation.navigate('LayoutManager')}
       >
-        <View style={styles.editButtonContainer}>
-          <Text style={styles.editButton}>Edit</Text>
-        </View>
+        <EditButtonContainer>
+          <EditLayout>Edit</EditLayout>
+        </EditButtonContainer>
       </TouchableOpacity>
     ),
   });
@@ -57,13 +56,13 @@ export class Groups extends Component {
 
   render() {
     return (
-      <View style={styles.container} onLayout={this.setDimensions}>
+      <Container onLayout={this.setDimensions}>
         <Layout
           renderEmptySpace={renderEmptySpace}
           container={this.state.layout}
           renderReservedSpace={Group}
         />
-      </View>
+      </Container>
     );
   }
 

--- a/src/components/Groups.js
+++ b/src/components/Groups.js
@@ -7,6 +7,7 @@ import R from 'ramda';
 
 import * as colors from '../constants/colors';
 import * as actions from '../actions/groups';
+import { selector } from '../utils/redux';
 import Group from './Group';
 
 export const styles = StyleSheet.create({
@@ -68,14 +69,12 @@ export class Groups extends Component {
   );
 }
 
-const getGroupIds = createSelector(
-  R.identity,
-  R.pipe(R.values, R.filter(R.propEq('type', 'Room')), R.map(R.prop('id'))),
-);
-
-export const mapStateToProps = state => ({
-  serverUrl: R.path(['server', 'url'], state),
-  groups: getGroupIds(state.groups),
+export const mapStateToProps = selector({
+  serverUrl: R.path(['server', 'url']),
+  groups: createSelector(
+    R.prop('groups'),
+    R.pipe(R.values, R.filter(R.propEq('type', 'Room')), R.map(R.prop('id'))),
+  ),
 });
 
 const mapDispatchToProps = {

--- a/src/components/Groups.js
+++ b/src/components/Groups.js
@@ -25,6 +25,10 @@ export class Groups extends Component {
     serverUrl: PropTypes.string.isRequired,
   };
 
+  static navigationOptions = {
+    title: 'Groups',
+  };
+
   componentDidMount() {
     this.props.fetchAllGroups(this.props.serverUrl);
   }

--- a/src/components/Groups.js
+++ b/src/components/Groups.js
@@ -8,15 +8,12 @@ import R from 'ramda';
 import * as colors from '../constants/colors';
 import * as actions from '../actions/groups';
 import { selector } from '../utils/redux';
+import Layout from './Layout';
 import Group from './Group';
 
 export const styles = StyleSheet.create({
   container: {
-    flexWrap: 'wrap',
-    flexDirection: 'row',
-    height: '100%',
-    width: '100%',
-    alignItems: 'center',
+    flex: 1,
   },
 
   editButtonContainer: {
@@ -28,6 +25,8 @@ export const styles = StyleSheet.create({
     fontSize: 18,
   },
 });
+
+const renderEmptySpace = R.always(null);
 
 export class Groups extends Component {
   static propTypes = {
@@ -50,23 +49,28 @@ export class Groups extends Component {
     ),
   });
 
+  state = { layout: null };
+
   componentDidMount() {
     this.props.fetchAllGroups(this.props.serverUrl);
   }
 
   render() {
-    return <View style={styles.container}>{this.renderContent()}</View>;
+    return (
+      <View style={styles.container} onLayout={this.setDimensions}>
+        <Layout
+          renderEmptySpace={renderEmptySpace}
+          container={this.state.layout}
+          renderReservedSpace={Group}
+        />
+      </View>
+    );
   }
 
-  renderContent() {
-    const { groups } = this.props;
-
-    return groups.map(this.createGroup);
-  }
-
-  createGroup = (groupId, index) => (
-    <Group key={groupId} id={groupId} divide={index % 2 === 0} />
-  );
+  setDimensions = event => {
+    const { layout } = event.nativeEvent;
+    this.setState({ layout });
+  };
 }
 
 export const mapStateToProps = selector({

--- a/src/components/Groups.js
+++ b/src/components/Groups.js
@@ -68,14 +68,9 @@ export class Groups extends Component {
   );
 }
 
-const isRoom = R.compose(R.equals('Room'), R.prop('type'));
 const getGroupIds = createSelector(
-  groups => groups,
-  groups =>
-    Object.keys(groups)
-      .map(key => groups[key])
-      .filter(isRoom)
-      .map(group => group.id),
+  R.identity,
+  R.pipe(R.values, R.filter(R.propEq('type', 'Room')), R.map(R.prop('id'))),
 );
 
 export const mapStateToProps = state => ({

--- a/src/components/Groups.js
+++ b/src/components/Groups.js
@@ -1,10 +1,11 @@
-import { View, StyleSheet } from 'react-native';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import { createSelector } from 'reselect';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import R from 'ramda';
 
+import * as colors from '../constants/colors';
 import * as actions from '../actions/groups';
 import Group from './Group';
 
@@ -16,6 +17,15 @@ export const styles = StyleSheet.create({
     width: '100%',
     alignItems: 'center',
   },
+
+  editButtonContainer: {
+    marginRight: 16,
+  },
+
+  editButton: {
+    color: colors.navbar.text,
+    fontSize: 18,
+  },
 });
 
 export class Groups extends Component {
@@ -25,9 +35,19 @@ export class Groups extends Component {
     serverUrl: PropTypes.string.isRequired,
   };
 
-  static navigationOptions = {
+  static navigationOptions = props => ({
     title: 'Groups',
-  };
+    headerRight: (
+      <TouchableOpacity
+        title="Edit"
+        onPress={() => props.navigation.navigate('LayoutManager')}
+      >
+        <View style={styles.editButtonContainer}>
+          <Text style={styles.editButton}>Edit</Text>
+        </View>
+      </TouchableOpacity>
+    ),
+  });
 
   componentDidMount() {
     this.props.fetchAllGroups(this.props.serverUrl);

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -1,4 +1,4 @@
-import { View, StyleSheet } from 'react-native';
+import styled from 'styled-components/native';
 import { createSelector } from 'reselect';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
@@ -15,11 +15,9 @@ const extractDimensions = R.pick(['top', 'left', 'width', 'height']);
 export const RESERVED = 'reserved';
 export const EMPTY = 'empty';
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
-});
+const Container = styled.View`
+  flex: 1;
+`;
 
 export class Layout extends React.Component {
   static propTypes = {
@@ -49,9 +47,7 @@ export class Layout extends React.Component {
 
   render() {
     const dimensions = this.getDimensions();
-    const props = {
-      style: styles.container,
-    };
+    const props = {};
 
     if (dimensions) {
       const options = this.findOpenCells(dimensions).map(
@@ -67,7 +63,7 @@ export class Layout extends React.Component {
       props.children = options.concat(reservations);
     }
 
-    return <View {...props} />;
+    return <Container {...props} />;
   }
 
   /**

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -1,0 +1,267 @@
+import { View, PanResponder, StyleSheet, Dimensions } from 'react-native';
+import { createSelector } from 'reselect';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import React from 'react';
+import R from 'ramda';
+
+import LayoutSelection from './LayoutSelection';
+import * as actions from '../actions/layout';
+import LayoutOption from './LayoutOption';
+
+export const OPTIONS_PER_ROW = 4;
+export const fmtIndex = (x, y) => `${x}:${y}`;
+const extractDimensions = R.pick(['top', 'left', 'width', 'height']);
+
+const styles = StyleSheet.create({
+  container: {
+    flexGrow: 1,
+  },
+});
+
+export class Layout extends React.Component {
+  static propTypes = {
+    setDragActiveState: PropTypes.func.isRequired,
+    createCellGroup: PropTypes.func.isRequired,
+    navigation: PropTypes.object.isRequired,
+    active: PropTypes.object.isRequired,
+    container: PropTypes.shape({
+      height: PropTypes.number.isRequired,
+      width: PropTypes.number.isRequired,
+    }),
+    reserved: PropTypes.arrayOf(
+      PropTypes.shape({
+        height: PropTypes.number.isRequired,
+        width: PropTypes.number.isRequired,
+        x: PropTypes.number.isRequired,
+        y: PropTypes.number.isRequired,
+      }),
+    ),
+  };
+
+  static navigationOptions = {
+    title: 'Change layout',
+  };
+
+  layouts = {};
+  onPanResponderRelease = () => {
+    const { active } = this.props;
+
+    if (!R.isEmpty(active)) {
+      this.props.createCellGroup(this.props.active);
+      this.props.navigation.navigate('LayoutConfig');
+    }
+  };
+
+  onPanResponderMove = (event, { x0, y0, dx, dy }) => {
+    const layout = this.props.container;
+    const { height } = Dimensions.get('window');
+    y0 -= height - layout.height;
+
+    dx = x0 + dx;
+    dy = y0 + dy;
+
+    const left = Math.min(x0, dx);
+    const right = Math.max(x0, dx);
+    const top = Math.min(y0, dy);
+    const bottom = Math.max(y0, dy);
+
+    // Locate which cells intersect with the selection area.
+    const patches = R.toPairs(this.layouts).reduce(
+      (patches, [index, layout]) => {
+        const active = this.props.active.hasOwnProperty(index);
+
+        const xbounded = layout.x + layout.width >= left && layout.x <= right;
+        const ybounded = layout.y + layout.height > top && layout.y <= bottom;
+        const bounded = xbounded && ybounded;
+
+        if (bounded && !active) {
+          patches[index] = true;
+        } else if (!bounded && active) {
+          patches[index] = false;
+        }
+
+        return patches;
+      },
+      {},
+    );
+
+    if (!R.isEmpty(patches)) {
+      this.props.setDragActiveState(patches);
+    }
+  };
+
+  pan = PanResponder.create({
+    onStartShouldSetPanResponder: R.T,
+    onStartShouldSetPanResponderCapture: R.T,
+    onMoveShouldSetPanResponder: R.T,
+    onMoveShouldSetPanResponderCapture: R.T,
+
+    onPanResponderMove: this.onPanResponderMove,
+    onPanResponderRelease: this.onPanResponderRelease,
+  });
+
+  render() {
+    const dimensions = this.getDimensions();
+    const props = {
+      ...this.pan.panHandlers,
+      style: styles.container,
+    };
+
+    if (dimensions) {
+      const options = this.findOpenCells(dimensions).map(
+        this.renderOption,
+        this,
+      );
+
+      const reservations = this.findReservedCells(dimensions).map(
+        this.renderReservation,
+        this,
+      );
+
+      props.children = options.concat(reservations);
+    }
+
+    return <View {...props} />;
+  }
+
+  /**
+   * Find layouts not occupied by reserved cells.
+   * @param  {Object} dimensions - Data from this.getDimensions()
+   * @return {Object[]} - A list of available cell locations.
+   */
+  findOpenCells({ rows, ...dimensions }) {
+    const { reserved } = this.props;
+    const totalOptions = rows * OPTIONS_PER_ROW;
+    const reservationIndex = reserved.reduce((map, reserved) => {
+      const { x, y, width, height } = reserved;
+
+      // Index every X/Y coordinate occupied by the reservation.
+      for (let xi = x; xi < x + width; xi += 1) {
+        for (let yi = y; yi < y + height; yi += 1) {
+          map[fmtIndex(xi, yi)] = reserved;
+        }
+      }
+
+      return map;
+    }, {});
+
+    return Array(totalOptions)
+      .fill()
+      .reduce((cells, value, id) => {
+        const layout = this.getOptionLayout(dimensions, id);
+        const index = fmtIndex(layout.row - 1, layout.col - 1);
+
+        // Don't render a cell on this X/Y coordinate if it's occupied.
+        if (reservationIndex.hasOwnProperty(index)) return cells;
+
+        return cells.concat(layout);
+      }, []);
+  }
+
+  /**
+   * Turn every reserved cell group into exact coordinates.
+   * @param  {Object} dimensions - From this.getDimensions()
+   * @return {Object[]} - Reservation cell layouts.
+   */
+  findReservedCells({ width, height }) {
+    const { reserved } = this.props;
+
+    return reserved.map(reservation => ({
+      reservation,
+      layout: {
+        height: reservation.height * height,
+        width: reservation.width * width,
+        left: reservation.x * width,
+        top: reservation.y * height,
+      },
+    }));
+  }
+
+  /**
+   * Calculates the ideal height/width of every cell
+   * to maximize screen usage.
+   * @return {Object} - height/width values and the number of
+   * expected rows.
+   */
+  getDimensions() {
+    if (!this.props.container) {
+      return null;
+    }
+
+    const { width, height } = this.props.container;
+    const size = width / OPTIONS_PER_ROW;
+
+    const rows = Math.floor(height / size);
+    const leftOver = height - rows * size;
+
+    return {
+      height: size + leftOver / rows,
+      width: size,
+      rows,
+    };
+  }
+
+  // This would be so much easier with CSS grid.
+  getOptionLayout({ height, width }, id) {
+    // Compensate for 0-based indexing.
+    id += 1;
+
+    const row = Math.ceil(id / 4);
+    const col = id - (row - 1) * 4;
+
+    return {
+      left: (col - 1) * width,
+      top: (row - 1) * height,
+      height,
+      width,
+      row,
+      col,
+    };
+  }
+
+  renderOption(layout) {
+    const values = extractDimensions(layout);
+    const index = fmtIndex(layout.row, layout.col);
+    const setLayout = event => (this.layouts[index] = event.nativeEvent.layout);
+    const active = this.props.active.hasOwnProperty(index);
+
+    return (
+      <LayoutOption
+        onLayout={setLayout}
+        active={active}
+        key={index}
+        id={index}
+        {...values}
+      />
+    );
+  }
+
+  renderReservation({ reservation, layout }) {
+    const values = extractDimensions(layout);
+    const index = fmtIndex(reservation.x + 1, reservation.y + 1);
+    const setLayout = event => (this.layouts[index] = event.nativeEvent.layout);
+
+    return (
+      <LayoutSelection
+        onLayout={setLayout}
+        key={index}
+        id={index}
+        {...values}
+      />
+    );
+  }
+}
+
+const getReservationList = createSelector(R.identity, R.values);
+export const mapStateToProps = state => ({
+  reserved: getReservationList(R.path(['layout', 'reserved'], state)),
+  active: R.path(['layout', 'active'], state),
+});
+
+const mapDispatchToProps = {
+  setDragActiveState: actions.setDragActiveState,
+  createCellGroup: actions.createCellGroup,
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(Layout);

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -6,6 +6,7 @@ import React from 'react';
 import R from 'ramda';
 
 import * as actions from '../actions/layout';
+import { selector } from '../utils/redux';
 
 export const OPTIONS_PER_ROW = 4;
 export const fmtIndex = (x, y) => `${x}:${y}`;
@@ -195,10 +196,9 @@ export class Layout extends React.Component {
   }
 }
 
-const getReservationList = createSelector(R.identity, R.values);
-export const mapStateToProps = state => ({
-  reserved: getReservationList(R.path(['layout', 'reserved'], state)),
-  active: R.path(['layout', 'active'], state),
+export const mapStateToProps = selector({
+  reserved: createSelector(R.path(['layout', 'reserved']), R.values),
+  active: R.path(['layout', 'active']),
 });
 
 const mapDispatchToProps = {

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -12,9 +12,12 @@ export const OPTIONS_PER_ROW = 4;
 export const fmtIndex = (x, y) => `${x}:${y}`;
 const extractDimensions = R.pick(['top', 'left', 'width', 'height']);
 
+export const RESERVED = 'reserved';
+export const EMPTY = 'empty';
+
 const styles = StyleSheet.create({
   container: {
-    flexGrow: 1,
+    flex: 1,
   },
 });
 
@@ -169,7 +172,10 @@ export class Layout extends React.Component {
     const index = fmtIndex(layout.col - 1, layout.row - 1);
     const active = this.props.active.hasOwnProperty(index);
     const setLayout = event =>
-      this.props.onCellLayout(index, this.extractLayout(event));
+      this.props.onCellLayout(index, {
+        layout: this.extractLayout(event),
+        type: EMPTY,
+      });
 
     return (
       <EmptySpace
@@ -187,7 +193,10 @@ export class Layout extends React.Component {
     const values = extractDimensions(layout);
     const index = fmtIndex(reservation.x, reservation.y);
     const setLayout = event =>
-      this.props.onCellLayout(index, this.extractLayout(event));
+      this.props.onCellLayout(index, {
+        layout: this.extractLayout(event),
+        type: RESERVED,
+      });
 
     return (
       <Reservation onLayout={setLayout} key={index} id={index} {...values} />

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -24,7 +24,6 @@ export class Layout extends React.Component {
     setDragActiveState: PropTypes.func.isRequired,
     renderEmptySpace: PropTypes.func.isRequired,
     createCellGroup: PropTypes.func.isRequired,
-    navigation: PropTypes.object.isRequired,
     active: PropTypes.object.isRequired,
     onCellLayout: PropTypes.func,
     container: PropTypes.shape({
@@ -93,7 +92,7 @@ export class Layout extends React.Component {
       .fill()
       .reduce((cells, value, id) => {
         const layout = this.getOptionLayout(dimensions, id);
-        const index = fmtIndex(layout.row - 1, layout.col - 1);
+        const index = fmtIndex(layout.col - 1, layout.row - 1);
 
         // Don't render a cell on this X/Y coordinate if it's occupied.
         if (reservationIndex.hasOwnProperty(index)) return cells;
@@ -167,7 +166,7 @@ export class Layout extends React.Component {
   renderOption(layout) {
     const EmptySpace = this.props.renderEmptySpace;
     const values = extractDimensions(layout);
-    const index = fmtIndex(layout.row, layout.col);
+    const index = fmtIndex(layout.col - 1, layout.row - 1);
     const active = this.props.active.hasOwnProperty(index);
     const setLayout = event =>
       this.props.onCellLayout(index, this.extractLayout(event));
@@ -186,7 +185,7 @@ export class Layout extends React.Component {
   renderReservation({ reservation, layout }) {
     const Reservation = this.props.renderReservedSpace;
     const values = extractDimensions(layout);
-    const index = fmtIndex(reservation.x + 1, reservation.y + 1);
+    const index = fmtIndex(reservation.x, reservation.y);
     const setLayout = event =>
       this.props.onCellLayout(index, this.extractLayout(event));
 

--- a/src/components/LayoutConfig.js
+++ b/src/components/LayoutConfig.js
@@ -1,13 +1,176 @@
-import { View } from 'react-native';
 import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
 import React from 'react';
+import R from 'ramda';
+import {
+  TouchableOpacity,
+  ScrollView,
+  StyleSheet,
+  Button,
+  Text,
+  View,
+} from 'react-native';
+
+import * as colors from '../constants/colors';
+import * as actions from '../actions/layout';
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: colors.groups.bg,
+    flex: 1,
+  },
+
+  msg: {
+    color: colors.text,
+    fontSize: 20,
+  },
+
+  option: {
+    borderColor: colors.groups.divider,
+    backgroundColor: colors.groups.selected,
+    borderTopWidth: 1,
+    borderBottomWidth: 1,
+    height: 75,
+    flexDirection: 'row',
+    alignItems: 'center',
+    flex: 1,
+  },
+
+  radio: {
+    borderRadius: 50,
+    height: 16,
+    width: 16,
+    borderColor: colors.groups.radio,
+    borderWidth: 1,
+    marginRight: 16,
+    padding: 2,
+    marginLeft: 16,
+  },
+
+  selected: {
+    flex: 1,
+    backgroundColor: colors.groups.radio,
+    borderRadius: 50,
+  },
+
+  buttons: {
+    padding: 12,
+  },
+});
 
 export class LayoutConfig extends React.Component {
+  static propTypes = {
+    createGrouping: PropTypes.func.isRequired,
+    selectOption: PropTypes.func.isRequired,
+    selected: PropTypes.string,
+    groups: PropTypes.arrayOf(
+      PropTypes.shape({
+        name: PropTypes.string.isRequired,
+        id: PropTypes.string.isRequired,
+      }),
+    ).isRequired,
+    navigation: PropTypes.shape({
+      goBack: PropTypes.func.isRequired,
+    }).isRequired,
+  };
+
+  static defaultProps = {
+    selected: null,
+  };
+
+  static navigationOptions = {
+    title: 'Choose a group',
+  };
+
   render() {
-    return <View />;
+    const { groups, selected } = this.props;
+    const options = groups.map(this.renderOption, this);
+    const confirmText = selected ? 'Create' : 'Select an option';
+
+    return (
+      <View style={styles.container}>
+        <ScrollView>{options}</ScrollView>
+
+        <View style={styles.buttons}>
+          <Button
+            disabled={!selected}
+            title={confirmText}
+            onPress={this.create}
+          />
+        </View>
+      </View>
+    );
   }
+
+  renderOption({ id, name }) {
+    const { selected } = this.props;
+
+    return (
+      <GroupOption
+        onSelect={this.selectOption}
+        selected={selected === id}
+        title={name}
+        key={id}
+        id={id}
+      />
+    );
+  }
+
+  selectOption = groupId => {
+    const { selected } = this.props;
+
+    if (selected === groupId) {
+      return;
+    }
+
+    this.props.selectOption(groupId);
+  };
+
+  create = () => {
+    this.props.createGrouping();
+    this.props.navigation.goBack();
+  };
 }
 
-export const mapStateToProps = () => ({});
+export class GroupOption extends React.Component {
+  static propTypes = {
+    onSelect: PropTypes.func.isRequired,
+    id: PropTypes.string.isRequired,
+    selected: PropTypes.bool,
+    title: PropTypes.string,
+  };
 
-export default connect(mapStateToProps)(LayoutConfig);
+  render() {
+    const { selected, title } = this.props;
+
+    return (
+      <TouchableOpacity onPress={this.select}>
+        <View style={styles.option}>
+          <View style={styles.radio}>
+            {selected && <View style={styles.selected} />}
+          </View>
+
+          <Text style={styles.msg}>{title}</Text>
+        </View>
+      </TouchableOpacity>
+    );
+  }
+
+  select = () => this.props.onSelect(this.props.id);
+}
+
+export const mapStateToProps = state => ({
+  selected: R.path(['layout', 'newCellGroup', 'groupId'], state),
+  groups: [
+    { id: '1', name: 'Hall' },
+    { id: '2', name: 'Kitchen' },
+    { id: '3', name: 'Living Room' },
+  ],
+});
+
+const mapDispatchToProps = {
+  createGrouping: actions.createGrouping,
+  selectOption: actions.selectGroup,
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(LayoutConfig);

--- a/src/components/LayoutConfig.js
+++ b/src/components/LayoutConfig.js
@@ -62,6 +62,7 @@ export class LayoutConfig extends React.Component {
   static propTypes = {
     createGrouping: PropTypes.func.isRequired,
     deleteGrouping: PropTypes.func.isRequired,
+    persistLayouts: PropTypes.func.isRequired,
     updateGrouping: PropTypes.func.isRequired,
     selectOption: PropTypes.func.isRequired,
     isNewGroup: PropTypes.bool,
@@ -143,12 +144,14 @@ export class LayoutConfig extends React.Component {
 
     const handler = isNewGroup ? createGrouping : updateGrouping;
     handler();
+    this.props.persistLayouts();
 
     this.props.navigation.goBack();
   };
 
   delete = () => {
     this.props.deleteGrouping();
+    this.props.persistLayouts();
     this.props.navigation.goBack();
   };
 }
@@ -190,6 +193,7 @@ export const mapStateToProps = selector({
 const mapDispatchToProps = {
   createGrouping: actions.createGrouping,
   deleteGrouping: actions.deleteGrouping,
+  persistLayouts: actions.persistLayouts,
   updateGrouping: actions.updateGrouping,
   selectOption: actions.selectGroup,
 };

--- a/src/components/LayoutConfig.js
+++ b/src/components/LayoutConfig.js
@@ -1,3 +1,4 @@
+import { createSelector } from 'reselect';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -159,13 +160,14 @@ export class GroupOption extends React.Component {
   select = () => this.props.onSelect(this.props.id);
 }
 
+const getGroupList = createSelector(
+  R.identity,
+  R.compose(R.filter(R.compose(R.equals('Room'), R.prop('type'))), R.values),
+);
+
 export const mapStateToProps = state => ({
   selected: R.path(['layout', 'newCellGroup', 'groupId'], state),
-  groups: [
-    { id: '1', name: 'Hall' },
-    { id: '2', name: 'Kitchen' },
-    { id: '3', name: 'Living Room' },
-  ],
+  groups: getGroupList(R.path(['groups'], state)),
 });
 
 const mapDispatchToProps = {

--- a/src/components/LayoutConfig.js
+++ b/src/components/LayoutConfig.js
@@ -65,7 +65,7 @@ export class LayoutConfig extends React.Component {
     createGrouping: PropTypes.func.isRequired,
     updateGrouping: PropTypes.func.isRequired,
     selectOption: PropTypes.func.isRequired,
-    isNewGroup: PropTypes.bool.isRequired,
+    isNewGroup: PropTypes.bool,
     selected: PropTypes.string,
     groups: PropTypes.arrayOf(
       PropTypes.shape({

--- a/src/components/LayoutConfig.js
+++ b/src/components/LayoutConfig.js
@@ -63,7 +63,9 @@ const styles = StyleSheet.create({
 export class LayoutConfig extends React.Component {
   static propTypes = {
     createGrouping: PropTypes.func.isRequired,
+    updateGrouping: PropTypes.func.isRequired,
     selectOption: PropTypes.func.isRequired,
+    isNewGroup: PropTypes.bool.isRequired,
     selected: PropTypes.string,
     groups: PropTypes.arrayOf(
       PropTypes.shape({
@@ -97,7 +99,7 @@ export class LayoutConfig extends React.Component {
           <Button
             disabled={!selected}
             title={confirmText}
-            onPress={this.create}
+            onPress={this.save}
           />
         </View>
       </View>
@@ -128,8 +130,12 @@ export class LayoutConfig extends React.Component {
     this.props.selectOption(groupId);
   };
 
-  create = () => {
-    this.props.createGrouping();
+  save = () => {
+    const { isNewGroup, createGrouping, updateGrouping } = this.props;
+
+    const handler = isNewGroup ? createGrouping : updateGrouping;
+    handler();
+
     this.props.navigation.goBack();
   };
 }
@@ -162,7 +168,8 @@ export class GroupOption extends React.Component {
 }
 
 export const mapStateToProps = selector({
-  selected: R.path(['layout', 'newCellGroup', 'groupId']),
+  isNewGroup: R.path(['layout', 'cellGroup', 'isNewGroup']),
+  selected: R.path(['layout', 'cellGroup', 'groupId']),
   groups: createSelector(
     R.prop('groups'),
     R.pipe(R.values, R.filter(R.propEq('type', 'Room'))),
@@ -171,6 +178,7 @@ export const mapStateToProps = selector({
 
 const mapDispatchToProps = {
   createGrouping: actions.createGrouping,
+  updateGrouping: actions.updateGrouping,
   selectOption: actions.selectGroup,
 };
 

--- a/src/components/LayoutConfig.js
+++ b/src/components/LayoutConfig.js
@@ -1,0 +1,13 @@
+import { View } from 'react-native';
+import { connect } from 'react-redux';
+import React from 'react';
+
+export class LayoutConfig extends React.Component {
+  render() {
+    return <View />;
+  }
+}
+
+export const mapStateToProps = () => ({});
+
+export default connect(mapStateToProps)(LayoutConfig);

--- a/src/components/LayoutConfig.js
+++ b/src/components/LayoutConfig.js
@@ -1,64 +1,56 @@
+import { TouchableOpacity, ScrollView } from 'react-native';
+import styled from 'styled-components/native';
 import { createSelector } from 'reselect';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import React from 'react';
 import R from 'ramda';
-import {
-  TouchableOpacity,
-  ScrollView,
-  StyleSheet,
-  Button,
-  Text,
-  View,
-} from 'react-native';
 
 import * as colors from '../constants/colors';
 import * as actions from '../actions/layout';
 import { selector } from '../utils/redux';
 
-const styles = StyleSheet.create({
-  container: {
-    backgroundColor: colors.groups.bg,
-    flex: 1,
-  },
+const Container = styled.View`
+  background-color: ${colors.groups.bg};
+  flex: 1;
+`;
 
-  msg: {
-    color: colors.text,
-    fontSize: 20,
-  },
+const GroupName = styled.Text`
+  color: ${colors.text};
+  font-size: 20px;
+`;
 
-  option: {
-    borderColor: colors.groups.divider,
-    backgroundColor: colors.groups.selected,
-    borderTopWidth: 1,
-    borderBottomWidth: 1,
-    height: 75,
-    flexDirection: 'row',
-    alignItems: 'center',
-    flex: 1,
-  },
+const Option = styled.View`
+  background-color: ${colors.groups.selected};
+  border: 1px solid ${colors.groups.divider};
+  border-left-width: 0;
+  border-right-width: 0;
+  height: 75px;
+  flex-direction: row;
+  align-items: center;
+  flex: 1;
+`;
 
-  radio: {
-    borderRadius: 50,
-    height: 16,
-    width: 16,
-    borderColor: colors.groups.radio,
-    borderWidth: 1,
-    marginRight: 16,
-    padding: 2,
-    marginLeft: 16,
-  },
+const Buttons = styled.View`
+  padding: 12px;
+`;
 
-  selected: {
-    flex: 1,
-    backgroundColor: colors.groups.radio,
-    borderRadius: 50,
-  },
+const Radio = styled.View`
+  border-radius: 50;
+  height: 16px;
+  width: 16px;
+  border: 1px solid ${colors.groups.radio};
+  margin: 0 16px;
+  padding: 2px;
+`;
 
-  buttons: {
-    padding: 12,
-  },
-});
+const InnerRadio = styled.View`
+  flex: 1;
+  background-color: ${colors.groups.radio};
+  border-radius: 50;
+`;
+
+export const SaveButton = styled.Button``;
 
 export class LayoutConfig extends React.Component {
   static propTypes = {
@@ -92,17 +84,17 @@ export class LayoutConfig extends React.Component {
     const confirmText = selected ? 'Create' : 'Select an option';
 
     return (
-      <View style={styles.container}>
+      <Container>
         <ScrollView>{options}</ScrollView>
 
-        <View style={styles.buttons}>
-          <Button
+        <Buttons>
+          <SaveButton
             disabled={!selected}
             title={confirmText}
             onPress={this.save}
           />
-        </View>
-      </View>
+        </Buttons>
+      </Container>
     );
   }
 
@@ -153,13 +145,11 @@ export class GroupOption extends React.Component {
 
     return (
       <TouchableOpacity onPress={this.select}>
-        <View style={styles.option}>
-          <View style={styles.radio}>
-            {selected && <View style={styles.selected} />}
-          </View>
+        <Option>
+          <Radio>{selected && <InnerRadio />}</Radio>
 
-          <Text style={styles.msg}>{title}</Text>
-        </View>
+          <GroupName>{title}</GroupName>
+        </Option>
       </TouchableOpacity>
     );
   }

--- a/src/components/LayoutConfig.js
+++ b/src/components/LayoutConfig.js
@@ -32,7 +32,7 @@ const Option = styled.View`
 `;
 
 const Buttons = styled.View`
-  padding: 12px;
+  flex-direction: row;
 `;
 
 const Radio = styled.View`
@@ -50,11 +50,18 @@ const InnerRadio = styled.View`
   border-radius: 50;
 `;
 
+const ButtonWrapper = styled.View`
+  flex: 1;
+  padding: 12px;
+`;
+
 export const SaveButton = styled.Button``;
+export const DeleteButton = styled.Button.attrs({ color: colors.error })``;
 
 export class LayoutConfig extends React.Component {
   static propTypes = {
     createGrouping: PropTypes.func.isRequired,
+    deleteGrouping: PropTypes.func.isRequired,
     updateGrouping: PropTypes.func.isRequired,
     selectOption: PropTypes.func.isRequired,
     isNewGroup: PropTypes.bool,
@@ -79,20 +86,29 @@ export class LayoutConfig extends React.Component {
   };
 
   render() {
-    const { groups, selected } = this.props;
+    const { groups, selected, isNewGroup } = this.props;
     const options = groups.map(this.renderOption, this);
-    const confirmText = selected ? 'Create' : 'Select an option';
+    const newGroupConfirmText = selected ? 'Create' : 'Select an option';
+    const confirmText = isNewGroup ? newGroupConfirmText : 'Update';
 
     return (
       <Container>
         <ScrollView>{options}</ScrollView>
 
         <Buttons>
-          <SaveButton
-            disabled={!selected}
-            title={confirmText}
-            onPress={this.save}
-          />
+          {!isNewGroup && (
+            <ButtonWrapper>
+              <DeleteButton title="Delete" onPress={this.delete} />
+            </ButtonWrapper>
+          )}
+
+          <ButtonWrapper>
+            <SaveButton
+              disabled={!selected}
+              title={isNewGroup ? confirmText : 'update'}
+              onPress={this.save}
+            />
+          </ButtonWrapper>
         </Buttons>
       </Container>
     );
@@ -128,6 +144,11 @@ export class LayoutConfig extends React.Component {
     const handler = isNewGroup ? createGrouping : updateGrouping;
     handler();
 
+    this.props.navigation.goBack();
+  };
+
+  delete = () => {
+    this.props.deleteGrouping();
     this.props.navigation.goBack();
   };
 }
@@ -168,6 +189,7 @@ export const mapStateToProps = selector({
 
 const mapDispatchToProps = {
   createGrouping: actions.createGrouping,
+  deleteGrouping: actions.deleteGrouping,
   updateGrouping: actions.updateGrouping,
   selectOption: actions.selectGroup,
 };

--- a/src/components/LayoutConfig.js
+++ b/src/components/LayoutConfig.js
@@ -14,6 +14,7 @@ import {
 
 import * as colors from '../constants/colors';
 import * as actions from '../actions/layout';
+import { selector } from '../utils/redux';
 
 const styles = StyleSheet.create({
   container: {
@@ -160,14 +161,12 @@ export class GroupOption extends React.Component {
   select = () => this.props.onSelect(this.props.id);
 }
 
-const getGroupList = createSelector(
-  R.identity,
-  R.compose(R.filter(R.compose(R.equals('Room'), R.prop('type'))), R.values),
-);
-
-export const mapStateToProps = state => ({
-  selected: R.path(['layout', 'newCellGroup', 'groupId'], state),
-  groups: getGroupList(R.path(['groups'], state)),
+export const mapStateToProps = selector({
+  selected: R.path(['layout', 'newCellGroup', 'groupId']),
+  groups: createSelector(
+    R.prop('groups'),
+    R.pipe(R.values, R.filter(R.propEq('type', 'Room'))),
+  ),
 });
 
 const mapDispatchToProps = {

--- a/src/components/LayoutManager.js
+++ b/src/components/LayoutManager.js
@@ -1,43 +1,135 @@
-import { View, Dimensions, StyleSheet } from 'react-native';
+import { View, Dimensions, PanResponder } from 'react-native';
+import PropTypes from 'prop-types';
 import React from 'react';
+import R from 'ramda';
 
+import LayoutSelection from './LayoutSelection';
 import LayoutOption from './LayoutOption';
 
-const styles = StyleSheet.create({
-  container: {},
-});
+export const OPTIONS_PER_ROW = 4;
+const fmtIndex = (x, y) => `${x}:${y}`;
+const extractDimensions = R.pick(['top', 'left', 'width', 'height']);
 
 export class LayoutManager extends React.Component {
+  static propTypes = {
+    reserved: PropTypes.arrayOf(
+      PropTypes.shape({
+        height: PropTypes.number.isRequired,
+        width: PropTypes.number.isRequired,
+        x: PropTypes.number.isRequired,
+        y: PropTypes.number.isRequired,
+      }),
+    ),
+  };
+
+  static defaultProps = {
+    reserved: [],
+  };
+
+  pan = PanResponder.create({
+    onStartShouldSetPanResponder: R.T,
+    onStartShouldSetPanResponderCapture: R.T,
+    onMoveShouldSetPanResponder: R.T,
+    onMoveShouldSetPanResponderCapture: R.T,
+
+    onPanResponderMove: this.onPanResponderMove,
+    onPanResponderTerminate: this.onPanResponderTerminate,
+  });
+
   render() {
-    const { rows, optionsPerRow, ...dimensions } = this.getDimensions();
-    const totalOptions = rows * optionsPerRow;
+    const dimensions = this.getDimensions();
 
-    const options = Array(totalOptions)
-      .fill(dimensions)
-      .map(this.renderOption, this);
+    const options = this.findOpenCells(dimensions).map(this.renderOption, this);
+    const reservations = this.findReservedCells(dimensions).map(
+      this.renderReservation,
+      this,
+    );
 
-    return <View style={styles.container}>{options}</View>;
+    const cells = options.concat(reservations);
+
+    return <View {...this.pan.panHandlers}>{cells}</View>;
   }
 
+  // Placeholders.
+  onPanResponderMove = R.always(null);
+  onPanResponderTerminate = R.always(null);
+
+  /**
+   * Find layouts not occupied by reserved cells.
+   * @param  {Object} dimensions - Data from this.getDimensions()
+   * @return {Object[]} - A list of available cell locations.
+   */
+  findOpenCells({ rows, ...dimensions }) {
+    const { reserved } = this.props;
+    const totalOptions = rows * OPTIONS_PER_ROW;
+    const reservationIndex = reserved.reduce((map, reserved) => {
+      const { x, y, width, height } = reserved;
+
+      // Index every X/Y coordinate occupied by the reservation.
+      for (let xi = x; xi < x + width; xi += 1) {
+        for (let yi = y; yi < y + height; yi += 1) {
+          map[fmtIndex(xi, yi)] = reserved;
+        }
+      }
+
+      return map;
+    }, {});
+
+    return Array(totalOptions)
+      .fill()
+      .reduce((cells, value, id) => {
+        const layout = this.getOptionLayout(dimensions, id);
+        const index = fmtIndex(layout.col - 1, layout.row - 1);
+
+        // Don't render a cell on this X/Y coordinate if it's occupied.
+        if (reservationIndex.hasOwnProperty(index)) return cells;
+
+        return cells.concat(layout);
+      }, []);
+  }
+
+  /**
+   * Turn every reserved cell group into exact coordinates.
+   * @param  {Object} dimensions - From this.getDimensions()
+   * @return {Object[]} - Reservation cell layouts.
+   */
+  findReservedCells({ width, height }) {
+    const { reserved } = this.props;
+
+    return reserved.map(reservation => ({
+      reservation,
+      layout: {
+        height: reservation.height * height,
+        width: reservation.width * width,
+        left: reservation.x * width,
+        top: reservation.y * height,
+      },
+    }));
+  }
+
+  /**
+   * Calculates the ideal height/width of every cell
+   * to maximize screen usage.
+   * @return {Object} - height/width values and the number of
+   * expected rows.
+   */
   getDimensions() {
     const { width, height } = Dimensions.get('window');
 
-    const optionsPerRow = 4;
-    const size = width / optionsPerRow;
+    const size = width / OPTIONS_PER_ROW;
 
     const rows = Math.floor(height / size);
     const leftOver = height - rows * size;
 
     return {
       height: size + leftOver / rows,
-      optionsPerRow,
       width: size,
       rows,
     };
   }
 
   // This would be so much easier with CSS grid.
-  getLayout({ height, width }, id) {
+  getOptionLayout({ height, width }, id) {
     // Compensate for 0-based indexing.
     id += 1;
 
@@ -49,13 +141,23 @@ export class LayoutManager extends React.Component {
       top: (row - 1) * height,
       height,
       width,
+      row,
+      col,
     };
   }
 
-  renderOption(dimensions, id) {
-    const layout = this.getLayout(dimensions, id);
+  renderOption(layout) {
+    const values = extractDimensions(layout);
+    const index = fmtIndex(layout.col, layout.row);
 
-    return <LayoutOption key={id} {...layout} />;
+    return <LayoutOption key={index} {...values} />;
+  }
+
+  renderReservation({ reservation, layout }) {
+    const values = extractDimensions(layout);
+    const index = fmtIndex(reservation.x, reservation.y);
+
+    return <LayoutSelection key={index} {...values} />;
   }
 }
 

--- a/src/components/LayoutManager.js
+++ b/src/components/LayoutManager.js
@@ -1,0 +1,62 @@
+import { View, Dimensions, StyleSheet } from 'react-native';
+import React from 'react';
+
+import LayoutOption from './LayoutOption';
+
+const styles = StyleSheet.create({
+  container: {},
+});
+
+export class LayoutManager extends React.Component {
+  render() {
+    const { rows, optionsPerRow, ...dimensions } = this.getDimensions();
+    const totalOptions = rows * optionsPerRow;
+
+    const options = Array(totalOptions)
+      .fill(dimensions)
+      .map(this.renderOption, this);
+
+    return <View style={styles.container}>{options}</View>;
+  }
+
+  getDimensions() {
+    const { width, height } = Dimensions.get('window');
+
+    const optionsPerRow = 4;
+    const size = width / optionsPerRow;
+
+    const rows = Math.floor(height / size);
+    const leftOver = height - rows * size;
+
+    return {
+      height: size + leftOver / rows,
+      optionsPerRow,
+      width: size,
+      rows,
+    };
+  }
+
+  // This would be so much easier with CSS grid.
+  getLayout({ height, width }, id) {
+    // Compensate for 0-based indexing.
+    id += 1;
+
+    const row = Math.ceil(id / 4);
+    const col = id - (row - 1) * 4;
+
+    return {
+      left: (col - 1) * width,
+      top: (row - 1) * height,
+      height,
+      width,
+    };
+  }
+
+  renderOption(dimensions, id) {
+    const layout = this.getLayout(dimensions, id);
+
+    return <LayoutOption key={id} {...layout} />;
+  }
+}
+
+export default LayoutManager;

--- a/src/components/LayoutManager.js
+++ b/src/components/LayoutManager.js
@@ -1,4 +1,5 @@
-import { View, StyleSheet, PanResponder, Dimensions } from 'react-native';
+import { PanResponder, Dimensions } from 'react-native';
+import styled from 'styled-components/native';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -10,11 +11,9 @@ import LayoutOption from './LayoutOption';
 import { selector } from '../utils/redux';
 import Layout, { EMPTY } from './Layout';
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
-});
+const Container = styled.View`
+  flex: 1;
+`;
 
 export class LayoutManager extends React.Component {
   static propTypes = {
@@ -148,11 +147,7 @@ export class LayoutManager extends React.Component {
 
   render() {
     return (
-      <View
-        {...this.pan.panHandlers}
-        onLayout={this.setDimensions}
-        style={styles.container}
-      >
+      <Container {...this.pan.panHandlers} onLayout={this.setDimensions}>
         <Layout
           {...this.props}
           renderReservedSpace={LayoutSelection}
@@ -160,7 +155,7 @@ export class LayoutManager extends React.Component {
           renderEmptySpace={LayoutOption}
           onCellLayout={this.addLayout}
         />
-      </View>
+      </Container>
     );
   }
 

--- a/src/components/LayoutManager.js
+++ b/src/components/LayoutManager.js
@@ -104,7 +104,10 @@ export class LayoutManager extends React.Component {
       const valid = this.isValidSelection(bounds, { left, right, top, bottom });
       const focus = valid ? index : null;
 
-      this.props.setGroupHover(focus);
+      if (this.props.selected !== focus) {
+        this.props.setGroupHover(focus);
+      }
+
       return;
     }
 

--- a/src/components/LayoutManager.js
+++ b/src/components/LayoutManager.js
@@ -1,6 +1,12 @@
-import { View, StyleSheet } from 'react-native';
+import { View, StyleSheet, PanResponder, Dimensions } from 'react-native';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
 import React from 'react';
+import R from 'ramda';
 
+import LayoutSelection from './LayoutSelection';
+import * as actions from '../actions/layout';
+import LayoutOption from './LayoutOption';
 import Layout from './Layout';
 
 const styles = StyleSheet.create({
@@ -10,20 +16,111 @@ const styles = StyleSheet.create({
 });
 
 export class LayoutManager extends React.Component {
-  state = { layout: null };
+  static propTypes = {
+    setDragActiveState: PropTypes.func.isRequired,
+    createCellGroup: PropTypes.func.isRequired,
+    navigation: PropTypes.object.isRequired,
+    active: PropTypes.object.isRequired,
+  };
+
+  static navigationOptions = {
+    title: 'Change layout',
+  };
+
+  state = { dimensions: null };
+  layouts = {};
+
+  onPanResponderRelease = () => {
+    const { active } = this.props;
+    if (!R.isEmpty(active)) {
+      this.props.createCellGroup(this.props.active);
+      this.props.navigation.navigate('LayoutConfig');
+    }
+  };
+
+  onPanResponderMove = (event, { x0, y0, dx, dy }) => {
+    const layout = this.state.dimensions;
+    const { height } = Dimensions.get('window');
+    y0 -= height - layout.height;
+
+    dx = x0 + dx;
+    dy = y0 + dy;
+
+    const left = Math.min(x0, dx);
+    const right = Math.max(x0, dx);
+    const top = Math.min(y0, dy);
+    const bottom = Math.max(y0, dy);
+
+    // Locate which cells intersect with the selection area.
+    const patches = R.toPairs(this.layouts).reduce(
+      (patches, [index, layout]) => {
+        const active = this.props.active.hasOwnProperty(index);
+
+        const xbounded = layout.x + layout.width >= left && layout.x <= right;
+        const ybounded = layout.y + layout.height > top && layout.y <= bottom;
+        const bounded = xbounded && ybounded;
+
+        if (bounded && !active) {
+          patches[index] = true;
+        } else if (!bounded && active) {
+          patches[index] = false;
+        }
+
+        return patches;
+      },
+      {},
+    );
+
+    if (!R.isEmpty(patches)) {
+      this.props.setDragActiveState(patches);
+    }
+  };
+
+  pan = PanResponder.create({
+    onStartShouldSetPanResponder: R.T,
+    onStartShouldSetPanResponderCapture: R.T,
+    onMoveShouldSetPanResponder: R.T,
+    onMoveShouldSetPanResponderCapture: R.T,
+
+    onPanResponderMove: this.onPanResponderMove,
+    onPanResponderRelease: this.onPanResponderRelease,
+  });
 
   render() {
     return (
-      <View style={styles.container} onLayout={this.setDimensions}>
-        <Layout {...this.props} container={this.state.layout} />
+      <View
+        {...this.pan.panHandlers}
+        onLayout={this.setDimensions}
+        style={styles.container}
+      >
+        <Layout
+          {...this.props}
+          renderReservedSpace={LayoutSelection}
+          container={this.state.dimensions}
+          renderEmptySpace={LayoutOption}
+          onCellLayout={this.addLayout}
+        />
       </View>
     );
   }
 
   setDimensions = event => {
     const { layout } = event.nativeEvent;
-    this.setState({ layout });
+    this.setState({ dimensions: layout });
+  };
+
+  addLayout = (id, layout) => {
+    this.layouts[id] = layout;
   };
 }
 
-export default LayoutManager;
+export const mapStateToProps = state => ({
+  active: R.path(['layout', 'active'], state),
+});
+
+const mapDispatchToProps = {
+  setDragActiveState: actions.setDragActiveState,
+  createCellGroup: actions.createCellGroup,
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(LayoutManager);

--- a/src/components/LayoutManager.js
+++ b/src/components/LayoutManager.js
@@ -65,6 +65,7 @@ export class LayoutManager extends React.Component {
 
     if (selected) {
       this.props.editCellGroup(selected);
+      this.props.navigation.navigate('LayoutConfig');
     } else if (!R.isEmpty(active)) {
       this.props.createCellGroup(this.props.active);
       this.props.navigation.navigate('LayoutConfig');

--- a/src/components/LayoutManager.js
+++ b/src/components/LayoutManager.js
@@ -42,15 +42,15 @@ export class LayoutManager extends React.Component {
   onPanResponderMove = (event, { x0, y0, dx, dy }) => {
     const layout = this.state.dimensions;
     const { height } = Dimensions.get('window');
-    y0 -= height - layout.height;
+    const distanceFromTop = height - layout.height;
 
-    dx = x0 + dx;
-    dy = y0 + dy;
+    const start = { x: x0, y: y0 - distanceFromTop };
+    const end = { x: start.x + dx, y: start.y + dy };
 
-    const left = Math.min(x0, dx);
-    const right = Math.max(x0, dx);
-    const top = Math.min(y0, dy);
-    const bottom = Math.max(y0, dy);
+    const left = Math.min(start.x, end.x);
+    const right = Math.max(start.x, end.x);
+    const top = Math.min(start.y, end.y);
+    const bottom = Math.max(start.y, end.y);
 
     // Locate which cells intersect with the selection area.
     const patches = R.toPairs(this.layouts).reduce(

--- a/src/components/LayoutManager.js
+++ b/src/components/LayoutManager.js
@@ -1,4 +1,5 @@
 import { View, Dimensions, PanResponder } from 'react-native';
+import { createSelector } from 'reselect';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -15,6 +16,7 @@ const extractDimensions = R.pick(['top', 'left', 'width', 'height']);
 export class LayoutManager extends React.Component {
   static propTypes = {
     setDragActiveState: PropTypes.func.isRequired,
+    createCellGroup: PropTypes.func.isRequired,
     active: PropTypes.object.isRequired,
     reserved: PropTypes.arrayOf(
       PropTypes.shape({
@@ -26,12 +28,11 @@ export class LayoutManager extends React.Component {
     ),
   };
 
-  static defaultProps = {
-    reserved: [],
+  layouts = {};
+  onPanResponderRelease = () => {
+    this.props.createCellGroup(this.props.active);
   };
 
-  layouts = {};
-  onPanResponderTerminate = R.always(null);
   onPanResponderMove = (event, { x0, y0, dx, dy }) => {
     dx = x0 + dx;
     dy = y0 + dy;
@@ -73,8 +74,7 @@ export class LayoutManager extends React.Component {
     onMoveShouldSetPanResponderCapture: R.T,
 
     onPanResponderMove: this.onPanResponderMove,
-    onPanResponderTerminate: this.onPanResponderTerminate,
-    onPanResponderGrant: R.T,
+    onPanResponderRelease: this.onPanResponderRelease,
   });
 
   render() {
@@ -216,12 +216,15 @@ export class LayoutManager extends React.Component {
   }
 }
 
+const getReservationList = createSelector(R.identity, R.values);
 export const mapStateToProps = state => ({
+  reserved: getReservationList(R.path(['layout', 'reserved'], state)),
   active: R.path(['layout', 'active'], state),
 });
 
 const mapDispatchToProps = {
   setDragActiveState: actions.setDragActiveState,
+  createCellGroup: actions.createCellGroup,
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(LayoutManager);

--- a/src/components/LayoutManager.js
+++ b/src/components/LayoutManager.js
@@ -5,6 +5,7 @@ import React from 'react';
 import R from 'ramda';
 
 import LayoutSelection from './LayoutSelection';
+import * as actions from '../actions/layout';
 import LayoutOption from './LayoutOption';
 
 export const OPTIONS_PER_ROW = 4;
@@ -14,6 +15,7 @@ const extractDimensions = R.pick(['top', 'left', 'width', 'height']);
 export class LayoutManager extends React.Component {
   static propTypes = {
     setDragActiveState: PropTypes.func.isRequired,
+    active: PropTypes.object.isRequired,
     reserved: PropTypes.arrayOf(
       PropTypes.shape({
         height: PropTypes.number.isRequired,
@@ -155,9 +157,16 @@ export class LayoutManager extends React.Component {
     const values = extractDimensions(layout);
     const index = fmtIndex(layout.col, layout.row);
     const setLayout = layout => (this.layouts[index] = layout);
+    const active = this.props.active.hasOwnProperty(index);
 
     return (
-      <LayoutOption onLayout={setLayout} key={index} id={index} {...values} />
+      <LayoutOption
+        onLayout={setLayout}
+        active={active}
+        key={index}
+        id={index}
+        {...values}
+      />
     );
   }
 
@@ -177,9 +186,12 @@ export class LayoutManager extends React.Component {
   }
 }
 
-const mapStateToProps = () => ({});
+export const mapStateToProps = state => ({
+  active: R.path(['layout', 'active'], state),
+});
+
 const mapDispatchToProps = {
-  setDragActiveState: R.always(undefined),
+  setDragActiveState: actions.setDragActiveState,
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(LayoutManager);

--- a/src/components/LayoutManager.js
+++ b/src/components/LayoutManager.js
@@ -23,6 +23,7 @@ export class LayoutManager extends React.Component {
   static propTypes = {
     setDragActiveState: PropTypes.func.isRequired,
     createCellGroup: PropTypes.func.isRequired,
+    navigation: PropTypes.object.isRequired,
     active: PropTypes.object.isRequired,
     reserved: PropTypes.arrayOf(
       PropTypes.shape({
@@ -42,6 +43,7 @@ export class LayoutManager extends React.Component {
   state = { layout: null, NAVBAR_Y_OFFSET: 0 };
   onPanResponderRelease = () => {
     this.props.createCellGroup(this.props.active);
+    this.props.navigation.navigate('LayoutConfig');
   };
 
   onPanResponderMove = (event, { x0, y0, dx, dy }) => {

--- a/src/components/LayoutManager.js
+++ b/src/components/LayoutManager.js
@@ -7,6 +7,7 @@ import R from 'ramda';
 import LayoutSelection from './LayoutSelection';
 import * as actions from '../actions/layout';
 import LayoutOption from './LayoutOption';
+import { selector } from '../utils/redux';
 import Layout from './Layout';
 
 const styles = StyleSheet.create({
@@ -114,8 +115,8 @@ export class LayoutManager extends React.Component {
   };
 }
 
-export const mapStateToProps = state => ({
-  active: R.path(['layout', 'active'], state),
+export const mapStateToProps = selector({
+  active: R.path(['layout', 'active']),
 });
 
 const mapDispatchToProps = {

--- a/src/components/LayoutManager.js
+++ b/src/components/LayoutManager.js
@@ -78,11 +78,7 @@ export class LayoutManager extends React.Component {
   };
 
   pan = PanResponder.create({
-    onStartShouldSetPanResponder: R.T,
-    onStartShouldSetPanResponderCapture: R.T,
     onMoveShouldSetPanResponder: R.T,
-    onMoveShouldSetPanResponderCapture: R.T,
-
     onPanResponderMove: this.onPanResponderMove,
     onPanResponderRelease: this.onPanResponderRelease,
   });

--- a/src/components/LayoutManager.js
+++ b/src/components/LayoutManager.js
@@ -1,4 +1,5 @@
 import { View, Dimensions, PanResponder } from 'react-native';
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import React from 'react';
 import R from 'ramda';
@@ -7,11 +8,12 @@ import LayoutSelection from './LayoutSelection';
 import LayoutOption from './LayoutOption';
 
 export const OPTIONS_PER_ROW = 4;
-const fmtIndex = (x, y) => `${x}:${y}`;
+export const fmtIndex = (x, y) => `${x}:${y}`;
 const extractDimensions = R.pick(['top', 'left', 'width', 'height']);
 
 export class LayoutManager extends React.Component {
   static propTypes = {
+    setDragActiveState: PropTypes.func.isRequired,
     reserved: PropTypes.arrayOf(
       PropTypes.shape({
         height: PropTypes.number.isRequired,
@@ -26,6 +28,7 @@ export class LayoutManager extends React.Component {
     reserved: [],
   };
 
+  layouts = {};
   pan = PanResponder.create({
     onStartShouldSetPanResponder: R.T,
     onStartShouldSetPanResponderCapture: R.T,
@@ -51,8 +54,10 @@ export class LayoutManager extends React.Component {
   }
 
   // Placeholders.
-  onPanResponderMove = R.always(null);
   onPanResponderTerminate = R.always(null);
+  onPanResponderMove = () => {
+    this.props.setDragActiveState({ index: '0:0', active: true });
+  };
 
   /**
    * Find layouts not occupied by reserved cells.
@@ -149,16 +154,32 @@ export class LayoutManager extends React.Component {
   renderOption(layout) {
     const values = extractDimensions(layout);
     const index = fmtIndex(layout.col, layout.row);
+    const setLayout = layout => (this.layouts[index] = layout);
 
-    return <LayoutOption key={index} {...values} />;
+    return (
+      <LayoutOption onLayout={setLayout} key={index} id={index} {...values} />
+    );
   }
 
   renderReservation({ reservation, layout }) {
     const values = extractDimensions(layout);
     const index = fmtIndex(reservation.x, reservation.y);
+    const setLayout = layout => (this.layouts[index] = layout);
 
-    return <LayoutSelection key={index} {...values} />;
+    return (
+      <LayoutSelection
+        onLayout={setLayout}
+        key={index}
+        id={index}
+        {...values}
+      />
+    );
   }
 }
 
-export default LayoutManager;
+const mapStateToProps = () => ({});
+const mapDispatchToProps = {
+  setDragActiveState: R.always(undefined),
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(LayoutManager);

--- a/src/components/LayoutManager.js
+++ b/src/components/LayoutManager.js
@@ -1,270 +1,29 @@
-import { View, PanResponder, StyleSheet, Dimensions } from 'react-native';
-import { createSelector } from 'reselect';
-import { connect } from 'react-redux';
-import PropTypes from 'prop-types';
+import { View, StyleSheet } from 'react-native';
 import React from 'react';
-import R from 'ramda';
 
-import LayoutSelection from './LayoutSelection';
-import * as actions from '../actions/layout';
-import LayoutOption from './LayoutOption';
-
-export const OPTIONS_PER_ROW = 4;
-export const fmtIndex = (x, y) => `${x}:${y}`;
-const extractDimensions = R.pick(['top', 'left', 'width', 'height']);
+import Layout from './Layout';
 
 const styles = StyleSheet.create({
   container: {
-    flexGrow: 1,
+    flex: 1,
   },
 });
 
 export class LayoutManager extends React.Component {
-  static propTypes = {
-    setDragActiveState: PropTypes.func.isRequired,
-    createCellGroup: PropTypes.func.isRequired,
-    navigation: PropTypes.object.isRequired,
-    active: PropTypes.object.isRequired,
-    reserved: PropTypes.arrayOf(
-      PropTypes.shape({
-        height: PropTypes.number.isRequired,
-        width: PropTypes.number.isRequired,
-        x: PropTypes.number.isRequired,
-        y: PropTypes.number.isRequired,
-      }),
-    ),
-  };
-
-  static navigationOptions = {
-    title: 'Change layout',
-  };
-
-  layouts = {};
-  state = { layout: null, NAVBAR_Y_OFFSET: 0 };
-  onPanResponderRelease = () => {
-    const { active } = this.props;
-
-    if (!R.isEmpty(active)) {
-      this.props.createCellGroup(this.props.active);
-      this.props.navigation.navigate('LayoutConfig');
-    }
-  };
-
-  onPanResponderMove = (event, { x0, y0, dx, dy }) => {
-    y0 -= this.state.NAVBAR_Y_OFFSET;
-
-    dx = x0 + dx;
-    dy = y0 + dy;
-
-    const left = Math.min(x0, dx);
-    const right = Math.max(x0, dx);
-    const top = Math.min(y0, dy);
-    const bottom = Math.max(y0, dy);
-
-    // Locate which cells intersect with the selection area.
-    const patches = R.toPairs(this.layouts).reduce(
-      (patches, [index, layout]) => {
-        const active = this.props.active.hasOwnProperty(index);
-
-        const xbounded = layout.x + layout.width >= left && layout.x <= right;
-        const ybounded = layout.y + layout.height > top && layout.y <= bottom;
-        const bounded = xbounded && ybounded;
-
-        if (bounded && !active) {
-          patches[index] = true;
-        } else if (!bounded && active) {
-          patches[index] = false;
-        }
-
-        return patches;
-      },
-      {},
-    );
-
-    if (!R.isEmpty(patches)) {
-      this.props.setDragActiveState(patches);
-    }
-  };
-
-  pan = PanResponder.create({
-    onStartShouldSetPanResponder: R.T,
-    onStartShouldSetPanResponderCapture: R.T,
-    onMoveShouldSetPanResponder: R.T,
-    onMoveShouldSetPanResponderCapture: R.T,
-
-    onPanResponderMove: this.onPanResponderMove,
-    onPanResponderRelease: this.onPanResponderRelease,
-  });
+  state = { layout: null };
 
   render() {
-    const dimensions = this.getDimensions();
-    const props = {
-      ...this.pan.panHandlers,
-      onLayout: this.setDimensions,
-      style: styles.container,
-    };
-
-    if (dimensions) {
-      const options = this.findOpenCells(dimensions).map(
-        this.renderOption,
-        this,
-      );
-
-      const reservations = this.findReservedCells(dimensions).map(
-        this.renderReservation,
-        this,
-      );
-
-      props.children = options.concat(reservations);
-    }
-
-    return <View {...props} />;
+    return (
+      <View style={styles.container} onLayout={this.setDimensions}>
+        <Layout {...this.props} container={this.state.layout} />
+      </View>
+    );
   }
 
-  setDimensions = ({ nativeEvent: { layout } }) => {
-    const { height } = Dimensions.get('window');
-    const NAVBAR_Y_OFFSET = height - layout.height;
-
-    this.setState({ layout, NAVBAR_Y_OFFSET });
+  setDimensions = event => {
+    const { layout } = event.nativeEvent;
+    this.setState({ layout });
   };
-
-  /**
-   * Find layouts not occupied by reserved cells.
-   * @param  {Object} dimensions - Data from this.getDimensions()
-   * @return {Object[]} - A list of available cell locations.
-   */
-  findOpenCells({ rows, ...dimensions }) {
-    const { reserved } = this.props;
-    const totalOptions = rows * OPTIONS_PER_ROW;
-    const reservationIndex = reserved.reduce((map, reserved) => {
-      const { x, y, width, height } = reserved;
-
-      // Index every X/Y coordinate occupied by the reservation.
-      for (let xi = x; xi < x + width; xi += 1) {
-        for (let yi = y; yi < y + height; yi += 1) {
-          map[fmtIndex(xi, yi)] = reserved;
-        }
-      }
-
-      return map;
-    }, {});
-
-    return Array(totalOptions)
-      .fill()
-      .reduce((cells, value, id) => {
-        const layout = this.getOptionLayout(dimensions, id);
-        const index = fmtIndex(layout.row - 1, layout.col - 1);
-
-        // Don't render a cell on this X/Y coordinate if it's occupied.
-        if (reservationIndex.hasOwnProperty(index)) return cells;
-
-        return cells.concat(layout);
-      }, []);
-  }
-
-  /**
-   * Turn every reserved cell group into exact coordinates.
-   * @param  {Object} dimensions - From this.getDimensions()
-   * @return {Object[]} - Reservation cell layouts.
-   */
-  findReservedCells({ width, height }) {
-    const { reserved } = this.props;
-
-    return reserved.map(reservation => ({
-      reservation,
-      layout: {
-        height: reservation.height * height,
-        width: reservation.width * width,
-        left: reservation.x * width,
-        top: reservation.y * height,
-      },
-    }));
-  }
-
-  /**
-   * Calculates the ideal height/width of every cell
-   * to maximize screen usage.
-   * @return {Object} - height/width values and the number of
-   * expected rows.
-   */
-  getDimensions() {
-    if (!this.state.layout) {
-      return null;
-    }
-
-    const { width, height } = this.state.layout;
-    const size = width / OPTIONS_PER_ROW;
-
-    const rows = Math.floor(height / size);
-    const leftOver = height - rows * size;
-
-    return {
-      height: size + leftOver / rows,
-      width: size,
-      rows,
-    };
-  }
-
-  // This would be so much easier with CSS grid.
-  getOptionLayout({ height, width }, id) {
-    // Compensate for 0-based indexing.
-    id += 1;
-
-    const row = Math.ceil(id / 4);
-    const col = id - (row - 1) * 4;
-
-    return {
-      left: (col - 1) * width,
-      top: (row - 1) * height,
-      height,
-      width,
-      row,
-      col,
-    };
-  }
-
-  renderOption(layout) {
-    const values = extractDimensions(layout);
-    const index = fmtIndex(layout.row, layout.col);
-    const setLayout = event => (this.layouts[index] = event.nativeEvent.layout);
-    const active = this.props.active.hasOwnProperty(index);
-
-    return (
-      <LayoutOption
-        onLayout={setLayout}
-        active={active}
-        key={index}
-        id={index}
-        {...values}
-      />
-    );
-  }
-
-  renderReservation({ reservation, layout }) {
-    const values = extractDimensions(layout);
-    const index = fmtIndex(reservation.x + 1, reservation.y + 1);
-    const setLayout = event => (this.layouts[index] = event.nativeEvent.layout);
-
-    return (
-      <LayoutSelection
-        onLayout={setLayout}
-        key={index}
-        id={index}
-        {...values}
-      />
-    );
-  }
 }
 
-const getReservationList = createSelector(R.identity, R.values);
-export const mapStateToProps = state => ({
-  reserved: getReservationList(R.path(['layout', 'reserved'], state)),
-  active: R.path(['layout', 'active'], state),
-});
-
-const mapDispatchToProps = {
-  setDragActiveState: actions.setDragActiveState,
-  createCellGroup: actions.createCellGroup,
-};
-
-export default connect(mapStateToProps, mapDispatchToProps)(LayoutManager);
+export default LayoutManager;

--- a/src/components/LayoutManager.js
+++ b/src/components/LayoutManager.js
@@ -42,8 +42,12 @@ export class LayoutManager extends React.Component {
   layouts = {};
   state = { layout: null, NAVBAR_Y_OFFSET: 0 };
   onPanResponderRelease = () => {
-    this.props.createCellGroup(this.props.active);
-    this.props.navigation.navigate('LayoutConfig');
+    const { active } = this.props;
+
+    if (!R.isEmpty(active)) {
+      this.props.createCellGroup(this.props.active);
+      this.props.navigation.navigate('LayoutConfig');
+    }
   };
 
   onPanResponderMove = (event, { x0, y0, dx, dy }) => {
@@ -77,7 +81,7 @@ export class LayoutManager extends React.Component {
       {},
     );
 
-    if (R.keys(patches).length) {
+    if (!R.isEmpty(patches)) {
       this.props.setDragActiveState(patches);
     }
   };
@@ -149,7 +153,7 @@ export class LayoutManager extends React.Component {
       .fill()
       .reduce((cells, value, id) => {
         const layout = this.getOptionLayout(dimensions, id);
-        const index = fmtIndex(layout.col - 1, layout.row - 1);
+        const index = fmtIndex(layout.row - 1, layout.col - 1);
 
         // Don't render a cell on this X/Y coordinate if it's occupied.
         if (reservationIndex.hasOwnProperty(index)) return cells;
@@ -221,7 +225,7 @@ export class LayoutManager extends React.Component {
 
   renderOption(layout) {
     const values = extractDimensions(layout);
-    const index = fmtIndex(layout.col, layout.row);
+    const index = fmtIndex(layout.row, layout.col);
     const setLayout = event => (this.layouts[index] = event.nativeEvent.layout);
     const active = this.props.active.hasOwnProperty(index);
 
@@ -238,7 +242,7 @@ export class LayoutManager extends React.Component {
 
   renderReservation({ reservation, layout }) {
     const values = extractDimensions(layout);
-    const index = fmtIndex(reservation.x, reservation.y);
+    const index = fmtIndex(reservation.x + 1, reservation.y + 1);
     const setLayout = event => (this.layouts[index] = event.nativeEvent.layout);
 
     return (

--- a/src/components/LayoutOption.js
+++ b/src/components/LayoutOption.js
@@ -4,12 +4,16 @@ import React from 'react';
 
 import * as colors from '../constants/colors';
 
-const styles = StyleSheet.create({
+export const styles = StyleSheet.create({
   container: {
     backgroundColor: colors.groups.bg,
     borderWidth: 0.5,
     borderColor: colors.groups.divider,
     position: 'absolute',
+  },
+
+  selected: {
+    backgroundColor: colors.groups.selected,
   },
 });
 
@@ -17,15 +21,23 @@ export class LayoutOption extends React.Component {
   static propTypes = {
     height: PropTypes.number.isRequired,
     width: PropTypes.number.isRequired,
+    active: PropTypes.bool.isRequired,
     left: PropTypes.number.isRequired,
     top: PropTypes.number.isRequired,
+    onLayout: PropTypes.func,
   };
 
   render() {
-    const { width, height, left, top } = this.props;
+    const { width, height, left, top, active, onLayout } = this.props;
+    const selectStyle = active && styles.selected;
     const inline = { width, height, left, top };
 
-    return <View style={[styles.container, inline]} />;
+    return (
+      <View
+        onLayout={onLayout}
+        style={[styles.container, selectStyle, inline]}
+      />
+    );
   }
 }
 

--- a/src/components/LayoutOption.js
+++ b/src/components/LayoutOption.js
@@ -1,0 +1,32 @@
+import { View, StyleSheet } from 'react-native';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import * as colors from '../constants/colors';
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: colors.groups.bg,
+    borderWidth: 0.5,
+    borderColor: colors.groups.divider,
+    position: 'absolute',
+  },
+});
+
+export class LayoutOption extends React.Component {
+  static propTypes = {
+    height: PropTypes.number.isRequired,
+    width: PropTypes.number.isRequired,
+    left: PropTypes.number.isRequired,
+    top: PropTypes.number.isRequired,
+  };
+
+  render() {
+    const { width, height, left, top } = this.props;
+    const inline = { width, height, left, top };
+
+    return <View style={[styles.container, inline]} />;
+  }
+}
+
+export default LayoutOption;

--- a/src/components/LayoutOption.js
+++ b/src/components/LayoutOption.js
@@ -1,6 +1,7 @@
 import styled from 'styled-components/native';
 import PropTypes from 'prop-types';
 import React from 'react';
+import R from 'ramda';
 
 import * as colors from '../constants/colors';
 
@@ -27,8 +28,8 @@ export class LayoutOption extends React.Component {
   };
 
   render() {
-    const { width, height, left, top, active, onLayout } = this.props;
-    const inline = { width, height, left, top };
+    const { active, onLayout } = this.props;
+    const inline = R.pick(['top', 'left', 'width', 'height'], this.props);
 
     return <Container active={active} onLayout={onLayout} style={inline} />;
   }

--- a/src/components/LayoutOption.js
+++ b/src/components/LayoutOption.js
@@ -1,21 +1,20 @@
-import { View, StyleSheet } from 'react-native';
+import styled from 'styled-components/native';
 import PropTypes from 'prop-types';
 import React from 'react';
 
 import * as colors from '../constants/colors';
 
-export const styles = StyleSheet.create({
-  container: {
-    backgroundColor: colors.groups.bg,
-    borderWidth: 0.5,
-    borderColor: colors.groups.divider,
-    position: 'absolute',
-  },
+export const Container = styled.View`
+  background-color: ${colors.groups.bg};
+  border: 0.5px solid ${colors.groups.divider};
+  position: absolute;
 
-  selected: {
-    backgroundColor: colors.groups.selected,
-  },
-});
+  ${props =>
+    props.active &&
+    `
+    background-color: ${colors.groups.selected};
+  `};
+`;
 
 export class LayoutOption extends React.Component {
   static propTypes = {
@@ -29,15 +28,9 @@ export class LayoutOption extends React.Component {
 
   render() {
     const { width, height, left, top, active, onLayout } = this.props;
-    const selectStyle = active && styles.selected;
     const inline = { width, height, left, top };
 
-    return (
-      <View
-        onLayout={onLayout}
-        style={[styles.container, selectStyle, inline]}
-      />
-    );
+    return <Container active={active} onLayout={onLayout} style={inline} />;
   }
 }
 

--- a/src/components/LayoutSelection.js
+++ b/src/components/LayoutSelection.js
@@ -9,12 +9,13 @@ export class LayoutSelection extends React.Component {
     width: PropTypes.number.isRequired,
     left: PropTypes.number.isRequired,
     top: PropTypes.number.isRequired,
+    onLayout: PropTypes.func,
   };
 
   render() {
     const inline = R.pick(['height', 'width', 'left', 'top'], this.props);
 
-    return <View style={[inline]} />;
+    return <View style={[inline]} onLayout={this.props.onLayout} />;
   }
 }
 

--- a/src/components/LayoutSelection.js
+++ b/src/components/LayoutSelection.js
@@ -1,10 +1,4 @@
-import {
-  View,
-  Text,
-  StyleSheet,
-  TouchableOpacity,
-  PanResponder,
-} from 'react-native';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -45,26 +39,13 @@ export class LayoutSelection extends React.Component {
     onLayout: PropTypes.func,
   };
 
-  pan = PanResponder.create({
-    onStartShouldSetPanResponder: R.T,
-    onMoveShouldSetPanResponder: R.T,
-    onPanResponderTerminationRequest: R.F,
-    onPanResponderMove: this.onPanResponderMove,
-  });
-
-  onPanResponderMove = R.always(undefined);
-
   render() {
     const inline = R.pick(['height', 'width', 'left', 'top'], this.props);
     const { groupTitle, blockWidth } = this.props;
     const titleSize = blockWidth === 1 && styles.smallTitle;
 
     return (
-      <View
-        {...this.pan.panHandlers}
-        style={[styles.container, inline]}
-        onLayout={this.props.onLayout}
-      >
+      <View style={[styles.container, inline]} onLayout={this.props.onLayout}>
         <TouchableOpacity style={styles.touchable}>
           <Text style={[styles.title, titleSize]}>{groupTitle}</Text>
         </TouchableOpacity>

--- a/src/components/LayoutSelection.js
+++ b/src/components/LayoutSelection.js
@@ -17,17 +17,14 @@ export const Container = styled.View`
   border: 0.5px solid ${colors.groups.divider};
   justify-content: center;
   align-items: center;
+  position: absolute;
 `;
 
 export const Title = styled.Text`
   font-size: 20px;
   color: ${colors.text};
 
-  ${props =>
-    props.small &&
-    `
-    font-size: 12px;
-  `};
+  ${props => props.small && 'font-size: 12px'};
 `;
 
 export class LayoutSelection extends React.Component {

--- a/src/components/LayoutSelection.js
+++ b/src/components/LayoutSelection.js
@@ -1,10 +1,43 @@
-import { View } from 'react-native';
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  PanResponder,
+} from 'react-native';
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import React from 'react';
 import R from 'ramda';
 
+import * as colors from '../constants/colors';
+
+export const styles = StyleSheet.create({
+  container: {
+    backgroundColor: colors.groups.bg,
+    borderWidth: 0.5,
+    borderColor: colors.groups.divider,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  title: {
+    fontSize: 20,
+    color: colors.text,
+  },
+  smallTitle: {
+    fontSize: 12,
+  },
+  touchable: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});
+
 export class LayoutSelection extends React.Component {
   static propTypes = {
+    blockWidth: PropTypes.number.isRequired,
+    groupTitle: PropTypes.string.isRequired,
     height: PropTypes.number.isRequired,
     width: PropTypes.number.isRequired,
     left: PropTypes.number.isRequired,
@@ -12,11 +45,42 @@ export class LayoutSelection extends React.Component {
     onLayout: PropTypes.func,
   };
 
+  pan = PanResponder.create({
+    onStartShouldSetPanResponder: R.T,
+    onMoveShouldSetPanResponder: R.T,
+    onPanResponderTerminationRequest: R.F,
+    onPanResponderMove: this.onPanResponderMove,
+  });
+
+  onPanResponderMove = R.always(undefined);
+
   render() {
     const inline = R.pick(['height', 'width', 'left', 'top'], this.props);
+    const { groupTitle, blockWidth } = this.props;
+    const titleSize = blockWidth === 1 && styles.smallTitle;
 
-    return <View style={[inline]} onLayout={this.props.onLayout} />;
+    return (
+      <View
+        {...this.pan.panHandlers}
+        style={[styles.container, inline]}
+        onLayout={this.props.onLayout}
+      >
+        <TouchableOpacity style={styles.touchable}>
+          <Text style={[styles.title, titleSize]}>{groupTitle}</Text>
+        </TouchableOpacity>
+      </View>
+    );
   }
 }
 
-export default LayoutSelection;
+export const mapStateToProps = (state, props) => {
+  const layout = R.path(['layout', 'reserved', props.id], state);
+  const groupId = R.prop('group', layout);
+
+  return {
+    groupTitle: R.path(['groups', groupId, 'name'], state),
+    blockWidth: R.prop('width', layout),
+  };
+};
+
+export default connect(mapStateToProps)(LayoutSelection);

--- a/src/components/LayoutSelection.js
+++ b/src/components/LayoutSelection.js
@@ -1,0 +1,21 @@
+import { View } from 'react-native';
+import PropTypes from 'prop-types';
+import React from 'react';
+import R from 'ramda';
+
+export class LayoutSelection extends React.Component {
+  static propTypes = {
+    height: PropTypes.number.isRequired,
+    width: PropTypes.number.isRequired,
+    left: PropTypes.number.isRequired,
+    top: PropTypes.number.isRequired,
+  };
+
+  render() {
+    const inline = R.pick(['height', 'width', 'left', 'top'], this.props);
+
+    return <View style={[inline]} />;
+  }
+}
+
+export default LayoutSelection;

--- a/src/components/LayoutSelection.js
+++ b/src/components/LayoutSelection.js
@@ -1,4 +1,4 @@
-import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import styled from 'styled-components/native';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -6,27 +6,29 @@ import R from 'ramda';
 
 import * as colors from '../constants/colors';
 
-export const styles = StyleSheet.create({
-  container: {
-    backgroundColor: colors.groups.bg,
-    borderWidth: 0.5,
-    borderColor: colors.groups.divider,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  title: {
-    fontSize: 20,
-    color: colors.text,
-  },
-  smallTitle: {
-    fontSize: 12,
-  },
-  touchable: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-});
+const Touchable = styled.TouchableOpacity`
+  flex: 1;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const Container = styled.View`
+  background-color: ${colors.groups.bg};
+  border: 0.5px solid ${colors.groups.divider};
+  justify-content: center;
+  align-items: center;
+`;
+
+export const Title = styled.Text`
+  font-size: 20px;
+  color: ${colors.text};
+
+  ${props =>
+    props.small &&
+    `
+    font-size: 12px;
+  `};
+`;
 
 export class LayoutSelection extends React.Component {
   static propTypes = {
@@ -42,14 +44,14 @@ export class LayoutSelection extends React.Component {
   render() {
     const inline = R.pick(['height', 'width', 'left', 'top'], this.props);
     const { groupTitle, blockWidth } = this.props;
-    const titleSize = blockWidth === 1 && styles.smallTitle;
+    const useSmallTitle = blockWidth === 1;
 
     return (
-      <View style={[styles.container, inline]} onLayout={this.props.onLayout}>
-        <TouchableOpacity style={styles.touchable}>
-          <Text style={[styles.title, titleSize]}>{groupTitle}</Text>
-        </TouchableOpacity>
-      </View>
+      <Container style={inline} onLayout={this.props.onLayout}>
+        <Touchable>
+          <Title small={useSmallTitle}>{groupTitle}</Title>
+        </Touchable>
+      </Container>
     );
   }
 }

--- a/src/components/Loading.js
+++ b/src/components/Loading.js
@@ -3,17 +3,21 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import * as actions from '../actions/filament';
+import * as filamentActions from '../actions/filament';
+import * as layoutActions from '../actions/layout';
 
 export class Loading extends React.Component {
   static propTypes = {
     getServerUrl: PropTypes.func.isRequired,
+    getLayouts: PropTypes.func.isRequired,
     navigation: PropTypes.shape({
       dispatch: PropTypes.func.isRequired,
     }).isRequired,
   };
 
   async componentWillMount() {
+    this.props.getLayouts();
+
     const { payload: url } = await this.props.getServerUrl();
     const route = url ? 'Groups' : 'ServerLink';
 
@@ -32,7 +36,8 @@ export class Loading extends React.Component {
 }
 
 const mapDispatchToProps = {
-  getServerUrl: actions.getServerUrl,
+  getServerUrl: filamentActions.getServerUrl,
+  getLayouts: layoutActions.getLayouts,
 };
 
 export default connect(null, mapDispatchToProps)(Loading);

--- a/src/components/Loading.js
+++ b/src/components/Loading.js
@@ -1,0 +1,38 @@
+import { NavigationActions } from 'react-navigation';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import * as actions from '../actions/filament';
+
+export class Loading extends React.Component {
+  static propTypes = {
+    getServerUrl: PropTypes.func.isRequired,
+    navigation: PropTypes.shape({
+      dispatch: PropTypes.func.isRequired,
+    }).isRequired,
+  };
+
+  async componentWillMount() {
+    const { payload: url } = await this.props.getServerUrl();
+    const route = url ? 'Groups' : 'ServerLink';
+
+    // Navigate without adding a back button.
+    const navigate = NavigationActions.reset({
+      index: 0,
+      actions: [NavigationActions.navigate({ routeName: route })],
+    });
+
+    this.props.navigation.dispatch(navigate);
+  }
+
+  render() {
+    return null;
+  }
+}
+
+const mapDispatchToProps = {
+  getServerUrl: actions.getServerUrl,
+};
+
+export default connect(null, mapDispatchToProps)(Loading);

--- a/src/components/ServerLink.js
+++ b/src/components/ServerLink.js
@@ -14,6 +14,7 @@ import {
 import * as actions from '../actions/filament';
 import * as colors from '../constants/colors';
 import { STATES } from '../reducers/filament';
+import { selector } from '../utils/redux';
 
 const styles = StyleSheet.create({
   container: {
@@ -117,17 +118,14 @@ export class ServerLink extends React.Component {
   };
 }
 
-export const mapStateToProps = state => {
-  const server = R.path(['server'], state);
-
-  return {
-    testingConnection: R.path(['testingConnection'], server),
-    pingSuccessful: R.path(['pingSuccessful'], server),
-    urlLooksValid: R.path(['urlLooksValid'], server),
-    lookupState: R.path(['state'], server),
-    serverUrl: R.path(['url'], server),
-  };
-};
+const withServerState = fn => R.pipe(R.prop('server'), fn);
+export const mapStateToProps = selector({
+  testingConnection: withServerState(R.prop('testingConnection')),
+  pingSuccessful: withServerState(R.prop('pingSuccessful')),
+  urlLooksValid: withServerState(R.prop('urlLooksValid')),
+  lookupState: withServerState(R.prop('state')),
+  serverUrl: withServerState(R.prop('url')),
+});
 
 const mapDispatchToProps = {
   updateServerUrl: actions.updateServerUrl,

--- a/src/components/ServerLink.js
+++ b/src/components/ServerLink.js
@@ -1,39 +1,31 @@
+import styled from 'styled-components/native';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import React from 'react';
 import R from 'ramda';
-import {
-  Text,
-  View,
-  Button,
-  Keyboard,
-  TextInput,
-  StyleSheet,
-} from 'react-native';
+import { Button, Keyboard } from 'react-native';
 
 import * as actions from '../actions/filament';
 import * as colors from '../constants/colors';
 import { STATES } from '../reducers/filament';
 import { selector } from '../utils/redux';
 
-const styles = StyleSheet.create({
-  container: {
-    padding: '20%',
-  },
-  urlInput: {
-    color: colors.text,
-    marginBottom: 8,
-    padding: 8,
-    paddingLeft: 4,
-    paddingRight: 4,
-    textAlign: 'center',
-  },
-  header: {
-    color: colors.text,
-    textAlign: 'center',
-    fontSize: 16,
-  },
-});
+const Container = styled.View`
+  padding: 20%;
+`;
+
+export const UrlInput = styled.TextInput`
+  color: ${colors.text};
+  margin-bottom: 8;
+  padding: 8px 4px;
+  text-align: center;
+`;
+
+const Header = styled.Text`
+  color: ${colors.text};
+  text-align: center;
+  font-size: 16px;
+`;
 
 export class ServerLink extends React.Component {
   static propTypes = {
@@ -61,14 +53,13 @@ export class ServerLink extends React.Component {
     }
 
     return (
-      <View style={styles.container}>
-        <Text style={styles.header}>What&apos;s your Filament URL?</Text>
+      <Container>
+        <Header>What&apos;s your Filament URL?</Header>
 
-        <TextInput
+        <UrlInput
           onChangeText={this.props.updateServerUrl}
           onSubmitEditing={this.pingServer}
           placeholder="http://..."
-          style={styles.urlInput}
           autoCapitalize="none"
           autoCorrect={false}
           returnKeyType="go"
@@ -80,7 +71,7 @@ export class ServerLink extends React.Component {
           title={this.getButtonText()}
           onPress={this.pingServer}
         />
-      </View>
+      </Container>
     );
   }
 

--- a/src/components/ServerLink.js
+++ b/src/components/ServerLink.js
@@ -1,13 +1,19 @@
-import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import React from 'react';
 import R from 'ramda';
+import {
+  Text,
+  View,
+  Button,
+  Keyboard,
+  TextInput,
+  StyleSheet,
+} from 'react-native';
 
 import * as actions from '../actions/filament';
 import * as colors from '../constants/colors';
 import { STATES } from '../reducers/filament';
-import Groups from './Groups';
 
 const styles = StyleSheet.create({
   container: {
@@ -32,17 +38,19 @@ export class ServerLink extends React.Component {
   static propTypes = {
     lookupState: PropTypes.oneOf(R.values(STATES)),
     updateServerUrl: PropTypes.func.isRequired,
-    getServerUrl: PropTypes.func.isRequired,
     pingServer: PropTypes.func.isRequired,
     testingConnection: PropTypes.bool,
     pingSuccessful: PropTypes.bool,
     urlLooksValid: PropTypes.bool,
     serverUrl: PropTypes.string,
+    navigation: PropTypes.shape({
+      navigate: PropTypes.func.isRequired,
+    }).isRequired,
   };
 
-  componentDidMount() {
-    this.props.getServerUrl();
-  }
+  static navigationOptions = {
+    title: 'Connect to Filament',
+  };
 
   render() {
     const { pingSuccessful, lookupState } = this.props;
@@ -51,13 +59,9 @@ export class ServerLink extends React.Component {
       return null;
     }
 
-    if (lookupState === STATES.FOUND) {
-      return <Groups />;
-    }
-
     return (
       <View style={styles.container}>
-        <Text style={styles.header}>{"What's your Filament URL?"}</Text>
+        <Text style={styles.header}>What&apos;s your Filament URL?</Text>
 
         <TextInput
           onChangeText={this.props.updateServerUrl}
@@ -99,11 +103,16 @@ export class ServerLink extends React.Component {
     return 'Connect';
   }
 
-  pingServer = () => {
+  pingServer = async () => {
     const { serverUrl } = this.props;
 
     if (!this.isDisabled()) {
-      this.props.pingServer(serverUrl);
+      const { payload } = await this.props.pingServer(serverUrl);
+
+      if (payload && payload.success) {
+        Keyboard.dismiss();
+        this.props.navigation.navigate('Groups');
+      }
     }
   };
 }
@@ -122,7 +131,6 @@ export const mapStateToProps = state => {
 
 const mapDispatchToProps = {
   updateServerUrl: actions.updateServerUrl,
-  getServerUrl: actions.getServerUrl,
   pingServer: actions.pingServer,
 };
 

--- a/src/components/__tests__/Group.test.js
+++ b/src/components/__tests__/Group.test.js
@@ -3,20 +3,9 @@ import { shallow } from 'enzyme';
 import React from 'react';
 import R from 'ramda';
 
-import { Group, styles, mapStateToProps } from '../Group';
+import { Group, Title, mapStateToProps, Container } from '../Group';
 
 describe('Group', () => {
-  const hasStyle = style => element => {
-    const styled = element.prop('style');
-    if (!styled) return false;
-    if (styled === style) return true;
-    if (Array.isArray(styled)) return R.any(R.equals(style), styled);
-    return false;
-  };
-
-  const isContainer = hasStyle(styles.container);
-  const isTitle = hasStyle(styles.title);
-
   const setup = merge => {
     const props = {
       serverUrl: 'http://filament/',
@@ -43,30 +32,30 @@ describe('Group', () => {
 
   it('shows the group name', () => {
     const { output, props } = setup();
-    const name = output.find('Text').prop('children');
+    const name = output.find(Title).prop('children');
 
     expect(name).toContain(props.group.name);
   });
 
-  it('shows when the group is online', () => {
+  it('shows when the group is on', () => {
     const { output } = setup();
-    const style = output.findWhere(isContainer).prop('style');
+    const container = output.find(Container);
 
-    expect(style).toContain(styles.on);
+    expect(container.prop('on')).toBe(true);
   });
 
-  it('shows when the group is offline', () => {
+  it('shows when the group is off', () => {
     const { output } = setup({
       group: {
-        anyOn: false,
         name: 'Hall',
+        anyOn: false,
         id: '3',
       },
     });
 
-    const style = output.findWhere(isContainer).prop('style');
+    const container = output.find(Container);
 
-    expect(style).toContain(styles.off);
+    expect(container.prop('on')).toBe(false);
   });
 
   it('toggles the group when tapped', () => {
@@ -79,10 +68,10 @@ describe('Group', () => {
     });
   });
 
-  it('shows inline styles', () => {
+  it('correctly positions the group', () => {
     const { output, props } = setup();
-    const container = output.findWhere(isContainer);
-    const inline = R.last(container.prop('style'));
+    const container = output.find(Container);
+    const inline = container.prop('style');
 
     expect(inline).toMatchObject({
       height: props.height,
@@ -94,16 +83,16 @@ describe('Group', () => {
 
   it('shows a smaller title for constrained blocks', () => {
     const { output } = setup({ blockWidth: 1 });
-    const title = output.findWhere(isTitle);
+    const title = output.find(Title);
 
-    expect(title.prop('style')).toContain(styles.smallTitle);
+    expect(title.prop('small')).toBe(true);
   });
 
   it('shows large title size for spaces that can fit', () => {
     const { output } = setup();
-    const title = output.findWhere(isTitle);
+    const title = output.find(Title);
 
-    expect(title.prop('style')).not.toContain(styles.smallTitle);
+    expect(title.prop('small')).toBe(false);
   });
 
   describe('mapStateToProps', () => {

--- a/src/components/__tests__/Group.test.js
+++ b/src/components/__tests__/Group.test.js
@@ -37,6 +37,13 @@ describe('Group', () => {
     expect(name).toContain(props.group.name);
   });
 
+  // The group ID can be known before the group is loaded.
+  it('survives when the group is undefined', () => {
+    const { output } = setup({ group: null });
+
+    expect(output.exists()).toBe(true);
+  });
+
   it('shows when the group is on', () => {
     const { output } = setup();
     const container = output.find(Container);

--- a/src/components/__tests__/Group.test.js
+++ b/src/components/__tests__/Group.test.js
@@ -6,17 +6,22 @@ import R from 'ramda';
 import { Group, styles, mapStateToProps } from '../Group';
 
 describe('Group', () => {
-  const isContainer = element => {
-    const style = element.prop('style');
-    if (!R.is(Function, R.prop('some', style))) return false;
-
-    return style.some(R.equals(styles.container));
+  const hasStyle = style => element => {
+    const styled = element.prop('style');
+    if (!styled) return false;
+    if (styled === style) return true;
+    if (Array.isArray(styled)) return R.any(R.equals(style), styled);
+    return false;
   };
+
+  const isContainer = hasStyle(styles.container);
+  const isTitle = hasStyle(styles.title);
 
   const setup = merge => {
     const props = {
       serverUrl: 'http://filament/',
       toggleLights: jest.fn(),
+      blockWidth: 2,
       height: 90,
       width: 60,
       left: 30,
@@ -77,7 +82,6 @@ describe('Group', () => {
   it('shows inline styles', () => {
     const { output, props } = setup();
     const container = output.findWhere(isContainer);
-
     const inline = R.last(container.prop('style'));
 
     expect(inline).toMatchObject({
@@ -88,6 +92,20 @@ describe('Group', () => {
     });
   });
 
+  it('shows a smaller title for constrained blocks', () => {
+    const { output } = setup({ blockWidth: 1 });
+    const title = output.findWhere(isTitle);
+
+    expect(title.prop('style')).toContain(styles.smallTitle);
+  });
+
+  it('shows large title size for spaces that can fit', () => {
+    const { output } = setup();
+    const title = output.findWhere(isTitle);
+
+    expect(title.prop('style')).not.toContain(styles.smallTitle);
+  });
+
   describe('mapStateToProps', () => {
     const select = (updates = {}, props = { id: '1:1' }) => {
       const defaultState = {
@@ -96,6 +114,10 @@ describe('Group', () => {
           reserved: {
             '1:1': {
               group: '16',
+              height: 1,
+              width: 2,
+              x: 1,
+              y: 1,
             },
           },
         },
@@ -138,6 +160,13 @@ describe('Group', () => {
       const { props, state } = select();
 
       expect(props.serverUrl).toBe(state.server.url);
+    });
+
+    it('fetches the width unit', () => {
+      const { props, state, ownProps } = select();
+
+      const expected = state.layout.reserved[ownProps.id].width;
+      expect(props.blockWidth).toBe(expected);
     });
   });
 });

--- a/src/components/__tests__/Groups.test.js
+++ b/src/components/__tests__/Groups.test.js
@@ -3,6 +3,7 @@ import { shallow } from 'enzyme';
 import React from 'react';
 
 import { Groups, mapStateToProps } from '../Groups';
+import Layout from '../Layout';
 import Group from '../Group';
 
 const createGroup = (fields = {}) => ({
@@ -23,8 +24,14 @@ describe('Groups', () => {
       ...merge,
     };
 
+    const output = shallow(<Groups {...props} />);
+    const dimensions = { width: 360, height: 560 };
+    const event = { nativeEvent: { layout: dimensions } };
+    output.simulate('layout', event);
+
     return {
-      output: shallow(<Groups {...props} />),
+      dimensions,
+      output,
       props,
     };
   };
@@ -36,26 +43,20 @@ describe('Groups', () => {
     expect(props.fetchAllGroups).toHaveBeenCalledWith(props.serverUrl);
   });
 
-  it('shows all the groups', () => {
-    const { output, props } = setup();
-    const groups = output.find(Group);
-
-    expect(groups.length).toBe(props.groups.length);
-  });
-
-  it('passes the group to the group component', () => {
-    const { output, props } = setup();
-    const groups = output.find(Group).first();
-
-    expect(groups.prop('id')).toEqual(props.groups[0]);
-  });
-
-  it('puts a middle divider on every second component', () => {
+  it('renders a layout', () => {
     const { output } = setup();
-    const groups = output.find(Group);
+    const layout = output.find(Layout);
 
-    expect(groups.at(0).prop('divide')).toBe(true);
-    expect(groups.at(1).prop('divide')).toBe(false);
+    expect(layout.exists()).toBe(true);
+    expect(layout.prop('renderReservedSpace')).toBe(Group);
+    expect(layout.prop('renderEmptySpace')).toEqual(expect.any(Function));
+  });
+
+  it('passes the computed layout', () => {
+    const { output, dimensions } = setup();
+    const layout = output.find(Layout);
+
+    expect(layout.prop('container')).toBe(dimensions);
   });
 
   describe('edit button', () => {

--- a/src/components/__tests__/Groups.test.js
+++ b/src/components/__tests__/Groups.test.js
@@ -58,6 +58,35 @@ describe('Groups', () => {
     expect(groups.at(1).prop('divide')).toBe(false);
   });
 
+  describe('edit button', () => {
+    const setup = merge => {
+      const props = {
+        navigation: {
+          navigate: jest.fn(),
+        },
+        ...merge,
+      };
+
+      const options = Groups.navigationOptions(props);
+
+      return {
+        node: options.headerRight,
+        props,
+      };
+    };
+
+    it('renders', () => {
+      setup();
+    });
+
+    it('navigates on press', () => {
+      const { node, props } = setup();
+      node.props.onPress();
+
+      expect(props.navigation.navigate).toHaveBeenCalledWith('LayoutManager');
+    });
+  });
+
   describe('mapStateToProps', () => {
     const select = (updates = {}) => {
       const defaultState = {

--- a/src/components/__tests__/Layout.test.js
+++ b/src/components/__tests__/Layout.test.js
@@ -160,10 +160,13 @@ describe('Layout', () => {
     options.forEach(invokeLayout);
     selections.forEach(invokeLayout);
 
-    expect(props.onCellLayout).toHaveBeenCalledWith(expect.any(String), layout);
-    expect(props.onCellLayout).toHaveBeenCalledTimes(
-      options.length + selections.length,
-    );
+    expect(props.onCellLayout).toHaveBeenCalledWith(expect.any(String), {
+      type: expect.any(String),
+      layout,
+    });
+
+    const calls = options.length + selections.length;
+    expect(props.onCellLayout).toHaveBeenCalledTimes(calls);
   });
 
   describe('mapStateToProps', () => {

--- a/src/components/__tests__/Layout.test.js
+++ b/src/components/__tests__/Layout.test.js
@@ -1,0 +1,309 @@
+import { Dimensions } from 'react-native';
+import update from 'immutability-helper';
+import { shallow } from 'enzyme';
+import React from 'react';
+import R from 'ramda';
+
+import LayoutSelection from '../LayoutSelection';
+import LayoutOption from '../LayoutOption';
+import { Layout, fmtIndex, mapStateToProps, OPTIONS_PER_ROW } from '../Layout';
+
+jest.spyOn(Dimensions, 'get');
+
+describe('Layout', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const setup = merge => {
+    const dimensions = { height: 630, width: 360 };
+    const props = {
+      setDragActiveState: jest.fn(),
+      createCellGroup: jest.fn(),
+      container: dimensions,
+      reserved: [],
+      active: {},
+      navigation: {
+        navigate: jest.fn(),
+      },
+      ...merge,
+    };
+
+    // Hack: perfectly divisible. Avoids leftover height calculations.
+    Dimensions.get.mockReturnValue(dimensions);
+
+    const output = shallow(<Layout {...props} />);
+    return {
+      dimensions,
+      output,
+      props,
+    };
+  };
+
+  it('renders', () => {
+    setup();
+  });
+
+  it('shows no options if layout is unset', () => {
+    const { output } = setup({ container: null });
+    const options = output.find(LayoutOption);
+
+    expect(options.length).toBe(0);
+  });
+
+  it('shows a screen of options', () => {
+    const { output, dimensions } = setup();
+    const options = output.find(LayoutOption);
+
+    const rows = dimensions.height / (dimensions.width / OPTIONS_PER_ROW);
+    const expected = Math.floor(rows * OPTIONS_PER_ROW);
+
+    expect(options.length).toBe(expected);
+  });
+
+  it('sets the proper size', () => {
+    const { output, dimensions } = setup();
+    const option = output.find(LayoutOption).first();
+
+    expect(option.prop('width')).toBe(dimensions.width / OPTIONS_PER_ROW);
+    expect(option.prop('height')).toBe(dimensions.width / OPTIONS_PER_ROW);
+  });
+
+  it('sets the proper position', () => {
+    const { output, dimensions } = setup();
+
+    const width = dimensions.width / OPTIONS_PER_ROW;
+    // 4th from the top.
+    const top = width * 3;
+    // 3rd from the left.
+    const left = width * 2;
+
+    const option = output.find(LayoutOption).at(14);
+
+    expect(option.prop('top')).toBe(top);
+    expect(option.prop('left')).toBe(left);
+  });
+
+  it('indicates whether cells are drag active', () => {
+    const { output } = setup({
+      active: { '1:2': true },
+    });
+
+    const first = output.find(LayoutOption).at(0);
+    const second = output.find(LayoutOption).at(1);
+
+    expect(first.prop('active')).toBe(false);
+    expect(second.prop('active')).toBe(true);
+  });
+
+  it('shows reserved spaces', () => {
+    const { output } = setup({
+      reserved: [
+        {
+          group: '1',
+          height: 2,
+          width: 2,
+          x: 0,
+          y: 0,
+        },
+      ],
+    });
+
+    const selection = output.find(LayoutSelection);
+    const options = output.find(LayoutOption);
+
+    expect(selection.length).toBe(1);
+
+    // 28 minus 4 from the reserved slot.
+    expect(options.length).toBe(24);
+  });
+
+  it('calculates the correct reservation position', () => {
+    const reserved = {
+      group: '1',
+      height: 4,
+      width: 3,
+      x: 2,
+      y: 1,
+    };
+
+    const { output, dimensions } = setup({
+      reserved: [reserved],
+    });
+
+    const size = dimensions.width / OPTIONS_PER_ROW;
+    const selection = output.find(LayoutSelection);
+
+    expect(selection.props()).toMatchObject({
+      height: reserved.height * size,
+      width: reserved.width * size,
+      left: reserved.x * size,
+      top: reserved.y * size,
+    });
+  });
+
+  describe('gesture', () => {
+    const gesture = merge => {
+      const result = setup(merge);
+
+      const invokeLayout = element => {
+        const layout = {
+          height: element.prop('height'),
+          width: element.prop('width'),
+          x: element.prop('left'),
+          y: element.prop('top'),
+        };
+
+        const event = { nativeEvent: { layout } };
+        element.simulate('layout', event);
+      };
+
+      result.output.find(LayoutOption).forEach(invokeLayout);
+      result.output.find(LayoutSelection).forEach(invokeLayout);
+
+      const {
+        onPanResponderMove,
+        onPanResponderRelease,
+      } = result.output.instance();
+
+      return {
+        ...result,
+        onMove: onPanResponderMove,
+        onRelease: onPanResponderRelease,
+      };
+    };
+
+    it('marks cells as active when dragging immediately over them', () => {
+      const { props, onMove } = gesture();
+
+      const event = { x0: 1, y0: 1, dx: 4, dy: 4 };
+      onMove(null, event);
+
+      const index = fmtIndex(1, 1);
+      const payload = { [index]: true };
+      expect(props.setDragActiveState).toHaveBeenCalledWith(payload);
+    });
+
+    it('does not mark cells as active while already active', () => {
+      const { props, onMove } = gesture({
+        active: { [fmtIndex(1, 1)]: true },
+      });
+
+      const event = { x0: 1, y0: 1, dx: 1, dy: 1 };
+      onMove(null, event);
+
+      expect(props.setDragActiveState).not.toHaveBeenCalled();
+    });
+
+    it('marks cells as selected if intersection exists', () => {
+      const { props, dimensions, onMove } = gesture();
+
+      // The whole top row.
+      const event = {
+        y0: 1,
+        dy: 1,
+        x0: dimensions.width - 1,
+        dx: -dimensions.width + 1,
+      };
+
+      onMove(null, event);
+
+      expect(props.setDragActiveState).toHaveBeenCalledWith({
+        [fmtIndex(1, 1)]: true,
+        [fmtIndex(1, 2)]: true,
+        [fmtIndex(1, 3)]: true,
+        [fmtIndex(1, 4)]: true,
+      });
+    });
+
+    it('marks cells inactive when drawn away', () => {
+      const { props, onMove } = gesture({
+        active: { '4:1': true },
+      });
+
+      const event = { y0: 1, dy: 1, x0: 1, dx: 1 };
+      onMove(null, event);
+
+      expect(props.setDragActiveState).toHaveBeenCalledWith({
+        [fmtIndex(4, 1)]: false,
+        [fmtIndex(1, 1)]: true,
+      });
+    });
+
+    it('shows a setup page after selecting cells', () => {
+      const { props, onRelease } = gesture({
+        active: { '1:1': true },
+      });
+
+      onRelease();
+      expect(props.createCellGroup).toHaveBeenCalledWith(props.active);
+      expect(props.navigation.navigate).toHaveBeenCalledWith('LayoutConfig');
+    });
+
+    it('does not trigger a config if nothing is selected', () => {
+      const { props, onRelease } = gesture({
+        active: {},
+      });
+
+      onRelease();
+
+      expect(props.createCellGroup).not.toHaveBeenCalled();
+      expect(props.navigation.navigate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('mapStateToProps', () => {
+    const select = (updates = {}) => {
+      const defaultState = {
+        layout: {
+          active: {
+            '1:1': true,
+            '2:1': true,
+            '3:1': true,
+          },
+          reserved: {
+            '0:1': {
+              group: '12',
+              height: 2,
+              width: 2,
+              x: 0,
+              y: 1,
+            },
+          },
+        },
+      };
+
+      const state = update(defaultState, updates);
+
+      return {
+        props: mapStateToProps(state),
+        state,
+      };
+    };
+
+    it('gets the set of active cells', () => {
+      const { props, state } = select();
+
+      expect(props.active).toEqual(state.layout.active);
+    });
+
+    it('retrieves every reserved slot', () => {
+      const { props, state } = select();
+
+      const expected = R.values(state.layout.reserved);
+      expect(props.reserved).toEqual(expected);
+    });
+
+    it('keeps the same reservation list between selects', () => {
+      const reserved = { '1:1': { x: 1, y: 1 } };
+      const updates = {
+        layout: {
+          reserved: { $set: reserved },
+        },
+      };
+
+      const { props } = select(updates);
+      expect(props.reserved).toBe(select(updates).props.reserved);
+    });
+  });
+});

--- a/src/components/__tests__/Layout.test.js
+++ b/src/components/__tests__/Layout.test.js
@@ -34,12 +34,14 @@ describe('Layout', () => {
 
     // Hack: perfectly divisible. Avoids leftover height calculations.
     Dimensions.get.mockReturnValue(dimensions);
+    const size = dimensions.width / OPTIONS_PER_ROW;
 
     const output = shallow(<Layout {...props} />);
     return {
       dimensions,
       output,
       props,
+      size,
     };
   };
 
@@ -130,11 +132,10 @@ describe('Layout', () => {
       y: 1,
     };
 
-    const { output, dimensions } = setup({
+    const { output, size } = setup({
       reserved: [reserved],
     });
 
-    const size = dimensions.width / OPTIONS_PER_ROW;
     const selection = output.find(LayoutSelection);
 
     expect(selection.props()).toMatchObject({
@@ -143,6 +144,23 @@ describe('Layout', () => {
       left: reserved.x * size,
       top: reserved.y * size,
     });
+  });
+
+  it('does not bleed reserved data', () => {
+    const { output, size } = setup({
+      reserved: [
+        { x: 0, y: 0, width: 2, height: 1, group: '1' },
+        { x: 0, y: 1, width: 1, height: 1, group: '2' },
+      ],
+    });
+
+    const [one, two] = output.find(LayoutSelection).map(R.identity);
+
+    expect(one.prop('left')).toBe(0);
+    expect(two.prop('left')).toBe(0);
+
+    expect(one.prop('top')).toBe(0);
+    expect(two.prop('top')).toBe(size);
   });
 
   it('invokes the layout handler for each layout', () => {

--- a/src/components/__tests__/Layout.test.js
+++ b/src/components/__tests__/Layout.test.js
@@ -6,7 +6,7 @@ import R from 'ramda';
 
 import LayoutSelection from '../LayoutSelection';
 import LayoutOption from '../LayoutOption';
-import { Layout, fmtIndex, mapStateToProps, OPTIONS_PER_ROW } from '../Layout';
+import { Layout, mapStateToProps, OPTIONS_PER_ROW } from '../Layout';
 
 jest.spyOn(Dimensions, 'get');
 
@@ -18,8 +18,11 @@ describe('Layout', () => {
   const setup = merge => {
     const dimensions = { height: 630, width: 360 };
     const props = {
+      renderReservedSpace: LayoutSelection,
+      renderEmptySpace: LayoutOption,
       setDragActiveState: jest.fn(),
       createCellGroup: jest.fn(),
+      onCellLayout: jest.fn(),
       container: dimensions,
       reserved: [],
       active: {},
@@ -142,114 +145,25 @@ describe('Layout', () => {
     });
   });
 
-  describe('gesture', () => {
-    const gesture = merge => {
-      const result = setup(merge);
+  it('invokes the layout handler for each layout', () => {
+    const { output, props } = setup();
 
-      const invokeLayout = element => {
-        const layout = {
-          height: element.prop('height'),
-          width: element.prop('width'),
-          x: element.prop('left'),
-          y: element.prop('top'),
-        };
-
-        const event = { nativeEvent: { layout } };
-        element.simulate('layout', event);
-      };
-
-      result.output.find(LayoutOption).forEach(invokeLayout);
-      result.output.find(LayoutSelection).forEach(invokeLayout);
-
-      const {
-        onPanResponderMove,
-        onPanResponderRelease,
-      } = result.output.instance();
-
-      return {
-        ...result,
-        onMove: onPanResponderMove,
-        onRelease: onPanResponderRelease,
-      };
-    };
-
-    it('marks cells as active when dragging immediately over them', () => {
-      const { props, onMove } = gesture();
-
-      const event = { x0: 1, y0: 1, dx: 4, dy: 4 };
-      onMove(null, event);
-
-      const index = fmtIndex(1, 1);
-      const payload = { [index]: true };
-      expect(props.setDragActiveState).toHaveBeenCalledWith(payload);
-    });
-
-    it('does not mark cells as active while already active', () => {
-      const { props, onMove } = gesture({
-        active: { [fmtIndex(1, 1)]: true },
+    const layout = { fake: true };
+    const invokeLayout = element =>
+      element.simulate('layout', {
+        nativeEvent: { layout },
       });
 
-      const event = { x0: 1, y0: 1, dx: 1, dy: 1 };
-      onMove(null, event);
+    const options = output.find(LayoutOption);
+    const selections = output.find(LayoutSelection);
 
-      expect(props.setDragActiveState).not.toHaveBeenCalled();
-    });
+    options.forEach(invokeLayout);
+    selections.forEach(invokeLayout);
 
-    it('marks cells as selected if intersection exists', () => {
-      const { props, dimensions, onMove } = gesture();
-
-      // The whole top row.
-      const event = {
-        y0: 1,
-        dy: 1,
-        x0: dimensions.width - 1,
-        dx: -dimensions.width + 1,
-      };
-
-      onMove(null, event);
-
-      expect(props.setDragActiveState).toHaveBeenCalledWith({
-        [fmtIndex(1, 1)]: true,
-        [fmtIndex(1, 2)]: true,
-        [fmtIndex(1, 3)]: true,
-        [fmtIndex(1, 4)]: true,
-      });
-    });
-
-    it('marks cells inactive when drawn away', () => {
-      const { props, onMove } = gesture({
-        active: { '4:1': true },
-      });
-
-      const event = { y0: 1, dy: 1, x0: 1, dx: 1 };
-      onMove(null, event);
-
-      expect(props.setDragActiveState).toHaveBeenCalledWith({
-        [fmtIndex(4, 1)]: false,
-        [fmtIndex(1, 1)]: true,
-      });
-    });
-
-    it('shows a setup page after selecting cells', () => {
-      const { props, onRelease } = gesture({
-        active: { '1:1': true },
-      });
-
-      onRelease();
-      expect(props.createCellGroup).toHaveBeenCalledWith(props.active);
-      expect(props.navigation.navigate).toHaveBeenCalledWith('LayoutConfig');
-    });
-
-    it('does not trigger a config if nothing is selected', () => {
-      const { props, onRelease } = gesture({
-        active: {},
-      });
-
-      onRelease();
-
-      expect(props.createCellGroup).not.toHaveBeenCalled();
-      expect(props.navigation.navigate).not.toHaveBeenCalled();
-    });
+    expect(props.onCellLayout).toHaveBeenCalledWith(expect.any(String), layout);
+    expect(props.onCellLayout).toHaveBeenCalledTimes(
+      options.length + selections.length,
+    );
   });
 
   describe('mapStateToProps', () => {

--- a/src/components/__tests__/Layout.test.js
+++ b/src/components/__tests__/Layout.test.js
@@ -89,7 +89,7 @@ describe('Layout', () => {
 
   it('indicates whether cells are drag active', () => {
     const { output } = setup({
-      active: { '1:2': true },
+      active: { '1:0': true },
     });
 
     const first = output.find(LayoutOption).at(0);

--- a/src/components/__tests__/LayoutConfig.test.js
+++ b/src/components/__tests__/LayoutConfig.test.js
@@ -1,9 +1,13 @@
 import update from 'immutability-helper';
-import { Button } from 'react-native';
 import { shallow } from 'enzyme';
 import React from 'react';
 
-import { LayoutConfig, GroupOption, mapStateToProps } from '../LayoutConfig';
+import {
+  mapStateToProps,
+  LayoutConfig,
+  GroupOption,
+  SaveButton,
+} from '../LayoutConfig';
 
 describe('LayoutConfig', () => {
   const setup = merge => {
@@ -61,7 +65,7 @@ describe('LayoutConfig', () => {
 
   it('disables the button by default', () => {
     const { output } = setup({ selected: null });
-    const button = output.find(Button);
+    const button = output.find(SaveButton);
 
     expect(button.prop('disabled')).toBe(true);
     expect(button.prop('title')).toMatch(/option/i);
@@ -69,7 +73,7 @@ describe('LayoutConfig', () => {
 
   it('enables the button once an option is selected', () => {
     const { output } = setup();
-    const button = output.find(Button);
+    const button = output.find(SaveButton);
 
     expect(button.prop('disabled')).toBe(false);
     expect(button.prop('title')).toMatch(/create/i);
@@ -95,7 +99,7 @@ describe('LayoutConfig', () => {
 
   it('reserves a slot when finished', () => {
     const { output, props } = setup();
-    output.find(Button).simulate('press');
+    output.find(SaveButton).simulate('press');
 
     expect(props.createGrouping).toHaveBeenCalled();
     expect(props.navigation.goBack).toHaveBeenCalled();
@@ -103,7 +107,7 @@ describe('LayoutConfig', () => {
 
   it('updates the group when in edit mode', () => {
     const { output, props } = setup({ isNewGroup: false });
-    output.find(Button).simulate('press');
+    output.find(SaveButton).simulate('press');
 
     expect(props.createGrouping).not.toHaveBeenCalled();
     expect(props.updateGrouping).toHaveBeenCalled();

--- a/src/components/__tests__/LayoutConfig.test.js
+++ b/src/components/__tests__/LayoutConfig.test.js
@@ -9,7 +9,9 @@ describe('LayoutConfig', () => {
   const setup = merge => {
     const props = {
       createGrouping: jest.fn(),
+      updateGrouping: jest.fn(),
       selectOption: jest.fn(),
+      isNewGroup: true,
       selected: '2',
       groups: [
         { id: '1', name: 'Hall' },
@@ -99,6 +101,15 @@ describe('LayoutConfig', () => {
     expect(props.navigation.goBack).toHaveBeenCalled();
   });
 
+  it('updates the group when in edit mode', () => {
+    const { output, props } = setup({ isNewGroup: false });
+    output.find(Button).simulate('press');
+
+    expect(props.createGrouping).not.toHaveBeenCalled();
+    expect(props.updateGrouping).toHaveBeenCalled();
+    expect(props.navigation.goBack).toHaveBeenCalled();
+  });
+
   describe('GroupOption', () => {
     const setup = merge => {
       const props = {
@@ -138,7 +149,8 @@ describe('LayoutConfig', () => {
         },
 
         layout: {
-          newCellGroup: {
+          cellGroup: {
+            isNewGroup: false,
             groupId: '18',
             selected: {},
           },
@@ -164,7 +176,7 @@ describe('LayoutConfig', () => {
     it('pulls the selected value from state', () => {
       const { props, state } = select();
 
-      expect(props.selected).toBe(state.layout.newCellGroup.groupId);
+      expect(props.selected).toBe(state.layout.cellGroup.groupId);
     });
 
     it('gets the list of groups', () => {
@@ -182,6 +194,12 @@ describe('LayoutConfig', () => {
       const updates = { $set: state };
 
       expect(select(updates).props.groups).toBe(select(updates).props.groups);
+    });
+
+    it('indicates whether the operation is create or edit', () => {
+      const { props, state } = select();
+
+      expect(props.isNewGroup).toBe(state.layout.cellGroup.isNewGroup);
     });
   });
 });

--- a/src/components/__tests__/LayoutConfig.test.js
+++ b/src/components/__tests__/LayoutConfig.test.js
@@ -1,0 +1,49 @@
+import update from 'immutability-helper';
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import { LayoutConfig, mapStateToProps } from '../LayoutConfig';
+
+describe('LayoutConfig', () => {
+  const setup = merge => {
+    const props = {
+      ...merge,
+    };
+
+    return {
+      output: shallow(<LayoutConfig {...props} />),
+      props,
+    };
+  };
+
+  it('renders', () => {
+    setup();
+  });
+
+  describe('mapStateToProps', () => {
+    const select = (updates = {}) => {
+      const defaultState = {
+        layout: {
+          newCellGroup: {
+            selected: {},
+          },
+        },
+      };
+
+      const state = update(defaultState, updates);
+
+      return {
+        props: mapStateToProps(state),
+        state,
+      };
+    };
+
+    it('works when nothing is defined', () => {
+      const { props } = select({
+        layout: { $set: {} },
+      });
+
+      expect(props).toEqual(expect.any(Object));
+    });
+  });
+});

--- a/src/components/__tests__/LayoutConfig.test.js
+++ b/src/components/__tests__/LayoutConfig.test.js
@@ -1,12 +1,24 @@
 import update from 'immutability-helper';
+import { Button } from 'react-native';
 import { shallow } from 'enzyme';
 import React from 'react';
 
-import { LayoutConfig, mapStateToProps } from '../LayoutConfig';
+import { LayoutConfig, GroupOption, mapStateToProps } from '../LayoutConfig';
 
 describe('LayoutConfig', () => {
   const setup = merge => {
     const props = {
+      createGrouping: jest.fn(),
+      selectOption: jest.fn(),
+      selected: '2',
+      groups: [
+        { id: '1', name: 'Hall' },
+        { id: '2', name: 'Kitchen' },
+        { id: '3', name: 'Living Room' },
+      ],
+      navigation: {
+        goBack: jest.fn(),
+      },
       ...merge,
     };
 
@@ -20,11 +32,107 @@ describe('LayoutConfig', () => {
     setup();
   });
 
+  it('shows all the group options', () => {
+    const { output, props } = setup();
+    const options = output.find(GroupOption);
+
+    const expected = props.groups.length;
+    expect(options.length).toBe(expected);
+  });
+
+  it('shows no selected group by default', () => {
+    const { output, props } = setup({ selected: null });
+    const options = output.find(GroupOption);
+
+    expect.assertions(props.groups.length);
+    options.forEach(option => expect(option.prop('selected')).toBe(false));
+  });
+
+  it('indicates which group is selected', () => {
+    const { output } = setup();
+    const options = output.find(GroupOption);
+
+    expect(options.at(0).prop('selected')).toBe(false);
+    expect(options.at(1).prop('selected')).toBe(true);
+    expect(options.at(2).prop('selected')).toBe(false);
+  });
+
+  it('disables the button by default', () => {
+    const { output } = setup({ selected: null });
+    const button = output.find(Button);
+
+    expect(button.prop('disabled')).toBe(true);
+    expect(button.prop('title')).toMatch(/option/i);
+  });
+
+  it('enables the button once an option is selected', () => {
+    const { output } = setup();
+    const button = output.find(Button);
+
+    expect(button.prop('disabled')).toBe(false);
+    expect(button.prop('title')).toMatch(/create/i);
+  });
+
+  it('selects the option when clicked', () => {
+    const { output, props } = setup();
+    const option = output.find(GroupOption).first();
+    const { id } = option.props();
+    option.simulate('select', id);
+
+    expect(props.selectOption).toHaveBeenCalledWith(id);
+  });
+
+  it('does not doubly select the same option', () => {
+    const selected = '8';
+    const { output, props } = setup({ selected });
+    const option = output.find(GroupOption).first();
+    option.simulate('select', selected);
+
+    expect(props.selectOption).not.toHaveBeenCalled();
+  });
+
+  it('reserves a slot when finished', () => {
+    const { output, props } = setup();
+    output.find(Button).simulate('press');
+
+    expect(props.createGrouping).toHaveBeenCalled();
+    expect(props.navigation.goBack).toHaveBeenCalled();
+  });
+
+  describe('GroupOption', () => {
+    const setup = merge => {
+      const props = {
+        title: 'Living Room',
+        onSelect: jest.fn(),
+        selected: false,
+        id: '5',
+        ...merge,
+      };
+
+      return {
+        output: shallow(<GroupOption {...props} />),
+        props,
+      };
+    };
+
+    it('renders', () => {
+      setup();
+    });
+
+    it('invokes onSelect when pressed', () => {
+      const { output, props } = setup();
+      output.simulate('press');
+
+      expect(props.onSelect).toHaveBeenCalledWith(props.id);
+    });
+  });
+
   describe('mapStateToProps', () => {
     const select = (updates = {}) => {
       const defaultState = {
         layout: {
           newCellGroup: {
+            groupId: '18',
             selected: {},
           },
         },
@@ -45,5 +153,13 @@ describe('LayoutConfig', () => {
 
       expect(props).toEqual(expect.any(Object));
     });
+
+    it('pulls the selected value from state', () => {
+      const { props, state } = select();
+
+      expect(props.selected).toBe(state.layout.newCellGroup.groupId);
+    });
+
+    it('gets the list of groups');
   });
 });

--- a/src/components/__tests__/LayoutConfig.test.js
+++ b/src/components/__tests__/LayoutConfig.test.js
@@ -16,6 +16,7 @@ describe('LayoutConfig', () => {
       createGrouping: jest.fn(),
       deleteGrouping: jest.fn(),
       updateGrouping: jest.fn(),
+      persistLayouts: jest.fn(),
       selectOption: jest.fn(),
       isNewGroup: true,
       selected: '2',
@@ -111,6 +112,7 @@ describe('LayoutConfig', () => {
     output.find(SaveButton).simulate('press');
 
     expect(props.createGrouping).toHaveBeenCalled();
+    expect(props.persistLayouts).toHaveBeenCalled();
     expect(props.navigation.goBack).toHaveBeenCalled();
   });
 
@@ -120,6 +122,7 @@ describe('LayoutConfig', () => {
 
     expect(props.createGrouping).not.toHaveBeenCalled();
     expect(props.updateGrouping).toHaveBeenCalled();
+    expect(props.persistLayouts).toHaveBeenCalled();
     expect(props.navigation.goBack).toHaveBeenCalled();
   });
 
@@ -132,6 +135,7 @@ describe('LayoutConfig', () => {
     button.simulate('press');
 
     expect(props.deleteGrouping).toHaveBeenCalled();
+    expect(props.persistLayouts).toHaveBeenCalled();
     expect(props.navigation.goBack).toHaveBeenCalled();
   });
 

--- a/src/components/__tests__/LayoutConfig.test.js
+++ b/src/components/__tests__/LayoutConfig.test.js
@@ -4,6 +4,7 @@ import React from 'react';
 
 import {
   mapStateToProps,
+  DeleteButton,
   LayoutConfig,
   GroupOption,
   SaveButton,
@@ -13,6 +14,7 @@ describe('LayoutConfig', () => {
   const setup = merge => {
     const props = {
       createGrouping: jest.fn(),
+      deleteGrouping: jest.fn(),
       updateGrouping: jest.fn(),
       selectOption: jest.fn(),
       isNewGroup: true,
@@ -79,6 +81,13 @@ describe('LayoutConfig', () => {
     expect(button.prop('title')).toMatch(/create/i);
   });
 
+  it('uses different wording when in edit mode', () => {
+    const { output } = setup({ isNewGroup: false });
+    const button = output.find(SaveButton);
+
+    expect(button.prop('title')).toMatch(/update/i);
+  });
+
   it('selects the option when clicked', () => {
     const { output, props } = setup();
     const option = output.find(GroupOption).first();
@@ -112,6 +121,25 @@ describe('LayoutConfig', () => {
     expect(props.createGrouping).not.toHaveBeenCalled();
     expect(props.updateGrouping).toHaveBeenCalled();
     expect(props.navigation.goBack).toHaveBeenCalled();
+  });
+
+  it('shows a delete button in edit mode', () => {
+    const { output, props } = setup({ isNewGroup: false });
+    const button = output.find(DeleteButton);
+
+    expect(button.exists()).toBe(true);
+
+    button.simulate('press');
+
+    expect(props.deleteGrouping).toHaveBeenCalled();
+    expect(props.navigation.goBack).toHaveBeenCalled();
+  });
+
+  it('does not show a delete button for new groups', () => {
+    const { output } = setup({ isNewGroup: true });
+    const button = output.find(DeleteButton);
+
+    expect(button.exists()).toBe(false);
   });
 
   describe('GroupOption', () => {

--- a/src/components/__tests__/LayoutConfig.test.js
+++ b/src/components/__tests__/LayoutConfig.test.js
@@ -130,6 +130,13 @@ describe('LayoutConfig', () => {
   describe('mapStateToProps', () => {
     const select = (updates = {}) => {
       const defaultState = {
+        groups: {
+          1: { id: '1', name: 'Hall', type: 'Room' },
+          2: { id: '2', name: 'Kitchen', type: 'Room' },
+          3: { id: '3', name: 'Living Room', type: 'Room' },
+          4: { id: '4', name: 'Custom group for $lights', type: 'LightGroup' },
+        },
+
         layout: {
           newCellGroup: {
             groupId: '18',
@@ -160,6 +167,21 @@ describe('LayoutConfig', () => {
       expect(props.selected).toBe(state.layout.newCellGroup.groupId);
     });
 
-    it('gets the list of groups');
+    it('gets the list of groups', () => {
+      const { props, state } = select();
+
+      expect(props.groups).toEqual([
+        state.groups[1],
+        state.groups[2],
+        state.groups[3],
+      ]);
+    });
+
+    it('does not change the group reference between renders', () => {
+      const { state } = select();
+      const updates = { $set: state };
+
+      expect(select(updates).props.groups).toBe(select(updates).props.groups);
+    });
   });
 });

--- a/src/components/__tests__/LayoutManager.test.js
+++ b/src/components/__tests__/LayoutManager.test.js
@@ -97,7 +97,7 @@ describe('LayoutManager', () => {
 
   it('indicates whether cells are drag active', () => {
     const { output } = setup({
-      active: { '2:1': true },
+      active: { '1:2': true },
     });
 
     const first = output.find(LayoutOption).at(0);
@@ -221,9 +221,9 @@ describe('LayoutManager', () => {
 
       expect(props.setDragActiveState).toHaveBeenCalledWith({
         [fmtIndex(1, 1)]: true,
-        [fmtIndex(2, 1)]: true,
-        [fmtIndex(3, 1)]: true,
-        [fmtIndex(4, 1)]: true,
+        [fmtIndex(1, 2)]: true,
+        [fmtIndex(1, 3)]: true,
+        [fmtIndex(1, 4)]: true,
       });
     });
 
@@ -249,6 +249,17 @@ describe('LayoutManager', () => {
       onRelease();
       expect(props.createCellGroup).toHaveBeenCalledWith(props.active);
       expect(props.navigation.navigate).toHaveBeenCalledWith('LayoutConfig');
+    });
+
+    it('does not trigger a config if nothing is selected', () => {
+      const { props, onRelease } = gesture({
+        active: {},
+      });
+
+      onRelease();
+
+      expect(props.createCellGroup).not.toHaveBeenCalled();
+      expect(props.navigation.navigate).not.toHaveBeenCalled();
     });
   });
 

--- a/src/components/__tests__/LayoutManager.test.js
+++ b/src/components/__tests__/LayoutManager.test.js
@@ -219,6 +219,7 @@ describe('LayoutManager', () => {
       onRelease();
 
       expect(props.editCellGroup).toHaveBeenCalledWith(props.selected);
+      expect(props.navigation.navigate).toHaveBeenCalledWith('LayoutConfig');
     });
 
     it('does not edit cell groups if unselected', () => {
@@ -229,6 +230,7 @@ describe('LayoutManager', () => {
       onRelease();
 
       expect(props.editCellGroup).not.toHaveBeenCalled();
+      expect(props.navigation.navigate).not.toHaveBeenCalled();
     });
   });
 

--- a/src/components/__tests__/LayoutManager.test.js
+++ b/src/components/__tests__/LayoutManager.test.js
@@ -1,46 +1,21 @@
-import { Dimensions } from 'react-native';
-import update from 'immutability-helper';
 import { shallow } from 'enzyme';
 import React from 'react';
-import R from 'ramda';
 
-import LayoutSelection from '../LayoutSelection';
-import LayoutOption from '../LayoutOption';
-import {
-  fmtIndex,
-  LayoutManager,
-  mapStateToProps,
-  OPTIONS_PER_ROW,
-} from '../LayoutManager';
-
-jest.spyOn(Dimensions, 'get');
+import { LayoutManager } from '../LayoutManager';
+import Layout from '../Layout';
 
 describe('LayoutManager', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
   const setup = merge => {
     const props = {
-      setDragActiveState: jest.fn(),
-      createCellGroup: jest.fn(),
-      reserved: [],
-      active: {},
       navigation: {
         navigate: jest.fn(),
       },
       ...merge,
     };
 
-    // Hack: perfectly divisible. Avoids leftover height calculations.
-    const dimensions = { height: 630, width: 360 };
-    Dimensions.get.mockReturnValue(dimensions);
-
     const output = shallow(<LayoutManager {...props} />);
-    const event = {
-      nativeEvent: { layout: dimensions },
-    };
-
+    const dimensions = { top: 0, left: 0, height: 560, width: 300 };
+    const event = { nativeEvent: { layout: dimensions } };
     output.simulate('layout', event);
 
     return {
@@ -54,267 +29,18 @@ describe('LayoutManager', () => {
     setup();
   });
 
-  it('shows no options if layout is unset', () => {
-    const { output } = setup();
-    output.setState({ layout: null });
-    const options = output.find(LayoutOption);
+  it('renders a layout', () => {
+    const { output, props } = setup();
+    const layout = output.find(Layout);
 
-    expect(options.length).toBe(0);
+    expect(layout.exists()).toBe(true);
+    expect(layout.prop('navigation')).toBe(props.navigation);
   });
 
-  it('shows a screen of options', () => {
+  it('passes container dimensions to the layout', () => {
     const { output, dimensions } = setup();
-    const options = output.find(LayoutOption);
+    const layout = output.find(Layout);
 
-    const rows = dimensions.height / (dimensions.width / OPTIONS_PER_ROW);
-    const expected = Math.floor(rows * OPTIONS_PER_ROW);
-
-    expect(options.length).toBe(expected);
-  });
-
-  it('sets the proper size', () => {
-    const { output, dimensions } = setup();
-    const option = output.find(LayoutOption).first();
-
-    expect(option.prop('width')).toBe(dimensions.width / OPTIONS_PER_ROW);
-    expect(option.prop('height')).toBe(dimensions.width / OPTIONS_PER_ROW);
-  });
-
-  it('sets the proper position', () => {
-    const { output, dimensions } = setup();
-
-    const width = dimensions.width / OPTIONS_PER_ROW;
-    // 4th from the top.
-    const top = width * 3;
-    // 3rd from the left.
-    const left = width * 2;
-
-    const option = output.find(LayoutOption).at(14);
-
-    expect(option.prop('top')).toBe(top);
-    expect(option.prop('left')).toBe(left);
-  });
-
-  it('indicates whether cells are drag active', () => {
-    const { output } = setup({
-      active: { '1:2': true },
-    });
-
-    const first = output.find(LayoutOption).at(0);
-    const second = output.find(LayoutOption).at(1);
-
-    expect(first.prop('active')).toBe(false);
-    expect(second.prop('active')).toBe(true);
-  });
-
-  it('shows reserved spaces', () => {
-    const { output } = setup({
-      reserved: [
-        {
-          group: '1',
-          height: 2,
-          width: 2,
-          x: 0,
-          y: 0,
-        },
-      ],
-    });
-
-    const selection = output.find(LayoutSelection);
-    const options = output.find(LayoutOption);
-
-    expect(selection.length).toBe(1);
-
-    // 28 minus 4 from the reserved slot.
-    expect(options.length).toBe(24);
-  });
-
-  it('calculates the correct reservation position', () => {
-    const reserved = {
-      group: '1',
-      height: 4,
-      width: 3,
-      x: 2,
-      y: 1,
-    };
-
-    const { output, dimensions } = setup({
-      reserved: [reserved],
-    });
-
-    const size = dimensions.width / OPTIONS_PER_ROW;
-    const selection = output.find(LayoutSelection);
-
-    expect(selection.props()).toMatchObject({
-      height: reserved.height * size,
-      width: reserved.width * size,
-      left: reserved.x * size,
-      top: reserved.y * size,
-    });
-  });
-
-  describe('gesture', () => {
-    const gesture = merge => {
-      const result = setup(merge);
-
-      const invokeLayout = element => {
-        const layout = {
-          height: element.prop('height'),
-          width: element.prop('width'),
-          x: element.prop('left'),
-          y: element.prop('top'),
-        };
-
-        const event = { nativeEvent: { layout } };
-        element.simulate('layout', event);
-      };
-
-      result.output.find(LayoutOption).forEach(invokeLayout);
-      result.output.find(LayoutSelection).forEach(invokeLayout);
-
-      const {
-        onPanResponderMove,
-        onPanResponderRelease,
-      } = result.output.instance();
-
-      return {
-        ...result,
-        onMove: onPanResponderMove,
-        onRelease: onPanResponderRelease,
-      };
-    };
-
-    it('marks cells as active when dragging immediately over them', () => {
-      const { props, onMove } = gesture();
-
-      const event = { x0: 1, y0: 1, dx: 4, dy: 4 };
-      onMove(null, event);
-
-      const index = fmtIndex(1, 1);
-      const payload = { [index]: true };
-      expect(props.setDragActiveState).toHaveBeenCalledWith(payload);
-    });
-
-    it('does not mark cells as active while already active', () => {
-      const { props, onMove } = gesture({
-        active: { [fmtIndex(1, 1)]: true },
-      });
-
-      const event = { x0: 1, y0: 1, dx: 1, dy: 1 };
-      onMove(null, event);
-
-      expect(props.setDragActiveState).not.toHaveBeenCalled();
-    });
-
-    it('marks cells as selected if intersection exists', () => {
-      const { props, dimensions, onMove } = gesture();
-
-      // The whole top row.
-      const event = {
-        y0: 1,
-        dy: 1,
-        x0: dimensions.width - 1,
-        dx: -dimensions.width + 1,
-      };
-
-      onMove(null, event);
-
-      expect(props.setDragActiveState).toHaveBeenCalledWith({
-        [fmtIndex(1, 1)]: true,
-        [fmtIndex(1, 2)]: true,
-        [fmtIndex(1, 3)]: true,
-        [fmtIndex(1, 4)]: true,
-      });
-    });
-
-    it('marks cells inactive when drawn away', () => {
-      const { props, onMove } = gesture({
-        active: { '4:1': true },
-      });
-
-      const event = { y0: 1, dy: 1, x0: 1, dx: 1 };
-      onMove(null, event);
-
-      expect(props.setDragActiveState).toHaveBeenCalledWith({
-        [fmtIndex(4, 1)]: false,
-        [fmtIndex(1, 1)]: true,
-      });
-    });
-
-    it('shows a setup page after selecting cells', () => {
-      const { props, onRelease } = gesture({
-        active: { '1:1': true },
-      });
-
-      onRelease();
-      expect(props.createCellGroup).toHaveBeenCalledWith(props.active);
-      expect(props.navigation.navigate).toHaveBeenCalledWith('LayoutConfig');
-    });
-
-    it('does not trigger a config if nothing is selected', () => {
-      const { props, onRelease } = gesture({
-        active: {},
-      });
-
-      onRelease();
-
-      expect(props.createCellGroup).not.toHaveBeenCalled();
-      expect(props.navigation.navigate).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('mapStateToProps', () => {
-    const select = (updates = {}) => {
-      const defaultState = {
-        layout: {
-          active: {
-            '1:1': true,
-            '2:1': true,
-            '3:1': true,
-          },
-          reserved: {
-            '0:1': {
-              group: '12',
-              height: 2,
-              width: 2,
-              x: 0,
-              y: 1,
-            },
-          },
-        },
-      };
-
-      const state = update(defaultState, updates);
-
-      return {
-        props: mapStateToProps(state),
-        state,
-      };
-    };
-
-    it('gets the set of active cells', () => {
-      const { props, state } = select();
-
-      expect(props.active).toEqual(state.layout.active);
-    });
-
-    it('retrieves every reserved slot', () => {
-      const { props, state } = select();
-
-      const expected = R.values(state.layout.reserved);
-      expect(props.reserved).toEqual(expected);
-    });
-
-    it('keeps the same reservation list between selects', () => {
-      const reserved = { '1:1': { x: 1, y: 1 } };
-      const updates = {
-        layout: {
-          reserved: { $set: reserved },
-        },
-      };
-
-      const { props } = select(updates);
-      expect(props.reserved).toBe(select(updates).props.reserved);
-    });
+    expect(layout.prop('container')).toBe(dimensions);
   });
 });

--- a/src/components/__tests__/LayoutManager.test.js
+++ b/src/components/__tests__/LayoutManager.test.js
@@ -1,10 +1,16 @@
 import { Dimensions } from 'react-native';
+import update from 'immutability-helper';
 import { shallow } from 'enzyme';
 import React from 'react';
 
-import { LayoutManager, fmtIndex, OPTIONS_PER_ROW } from '../LayoutManager';
 import LayoutSelection from '../LayoutSelection';
 import LayoutOption from '../LayoutOption';
+import {
+  fmtIndex,
+  LayoutManager,
+  mapStateToProps,
+  OPTIONS_PER_ROW,
+} from '../LayoutManager';
 
 jest.spyOn(Dimensions, 'get');
 
@@ -17,6 +23,7 @@ describe('LayoutManager', () => {
     const props = {
       setDragActiveState: jest.fn(),
       reserved: [],
+      active: {},
       ...merge,
     };
 
@@ -66,6 +73,18 @@ describe('LayoutManager', () => {
 
     expect(option.prop('top')).toBe(top);
     expect(option.prop('left')).toBe(left);
+  });
+
+  it('indicates whether cells are drag active', () => {
+    const { output } = setup({
+      active: { '2:1': true },
+    });
+
+    const first = output.find(LayoutOption).at(0);
+    const second = output.find(LayoutOption).at(1);
+
+    expect(first.prop('active')).toBe(false);
+    expect(second.prop('active')).toBe(true);
   });
 
   it('shows reserved spaces', () => {
@@ -144,6 +163,33 @@ describe('LayoutManager', () => {
       const index = fmtIndex(0, 0);
       const payload = { active: true, index };
       expect(props.setDragActiveState).toHaveBeenCalledWith(payload);
+    });
+  });
+
+  describe('mapStateToProps', () => {
+    const select = (updates = {}) => {
+      const defaultState = {
+        layout: {
+          active: {
+            '1:1': true,
+            '2:1': true,
+            '3:1': true,
+          },
+        },
+      };
+
+      const state = update(defaultState, updates);
+
+      return {
+        props: mapStateToProps(state),
+        state,
+      };
+    };
+
+    it('gets the set of active cells', () => {
+      const { props, state } = select();
+
+      expect(props.active).toEqual(state.layout.active);
     });
   });
 });

--- a/src/components/__tests__/LayoutManager.test.js
+++ b/src/components/__tests__/LayoutManager.test.js
@@ -1,0 +1,68 @@
+import { Dimensions } from 'react-native';
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import { LayoutManager } from '../LayoutManager';
+import LayoutOption from '../LayoutOption';
+
+jest.spyOn(Dimensions, 'get');
+
+describe('LayoutManager', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const setup = merge => {
+    const props = {
+      ...merge,
+    };
+
+    // Hack: perfectly divisible. Avoids leftover height calculations.
+    const dimensions = { height: 630, width: 360 };
+    Dimensions.get.mockReturnValue(dimensions);
+
+    return {
+      output: shallow(<LayoutManager {...props} />),
+      dimensions,
+      props,
+    };
+  };
+
+  it('renders', () => {
+    setup();
+  });
+
+  it('shows a screen of options', () => {
+    const { output, dimensions } = setup();
+    const options = output.find(LayoutOption);
+
+    const optionsPerRow = 4;
+    const rows = dimensions.height / (dimensions.width / optionsPerRow);
+    const expected = Math.floor(rows * optionsPerRow);
+
+    expect(options.length).toBe(expected);
+  });
+
+  it('sets the proper size', () => {
+    const { output, dimensions } = setup();
+    const option = output.find(LayoutOption).first();
+
+    expect(option.prop('width')).toBe(dimensions.width / 4);
+    expect(option.prop('height')).toBe(dimensions.width / 4);
+  });
+
+  it('sets the proper position', () => {
+    const { output, dimensions } = setup();
+
+    const width = dimensions.width / 4;
+    // 4th from the top.
+    const top = width * 3;
+    // 3rd from the left.
+    const left = width * 2;
+
+    const option = output.find(LayoutOption).at(14);
+
+    expect(option.prop('top')).toBe(top);
+    expect(option.prop('left')).toBe(left);
+  });
+});

--- a/src/components/__tests__/LayoutManager.test.js
+++ b/src/components/__tests__/LayoutManager.test.js
@@ -2,7 +2,7 @@ import { Dimensions } from 'react-native';
 import { shallow } from 'enzyme';
 import React from 'react';
 
-import { LayoutManager, OPTIONS_PER_ROW } from '../LayoutManager';
+import { LayoutManager, fmtIndex, OPTIONS_PER_ROW } from '../LayoutManager';
 import LayoutSelection from '../LayoutSelection';
 import LayoutOption from '../LayoutOption';
 
@@ -15,6 +15,7 @@ describe('LayoutManager', () => {
 
   const setup = merge => {
     const props = {
+      setDragActiveState: jest.fn(),
       reserved: [],
       ...merge,
     };
@@ -110,6 +111,39 @@ describe('LayoutManager', () => {
       width: reserved.width * size,
       left: reserved.x * size,
       top: reserved.y * size,
+    });
+  });
+
+  describe('gesture', () => {
+    const gesture = merge => {
+      const result = setup(merge);
+
+      const invokeLayout = element => {
+        const layout = {
+          height: element.prop('height'),
+          width: element.prop('width'),
+          left: element.prop('left'),
+          top: element.prop('top'),
+        };
+
+        element.simulate('layout', layout);
+      };
+
+      result.output.find(LayoutOption).forEach(invokeLayout);
+      result.output.find(LayoutSelection).forEach(invokeLayout);
+
+      return result;
+    };
+
+    it('marks cells as active when dragging immediately over them', () => {
+      const { output, props } = gesture();
+
+      const state = { x0: 1, y0: 1, dx: 4, dy: 4 };
+      output.instance().onPanResponderMove(null, state);
+
+      const index = fmtIndex(0, 0);
+      const payload = { active: true, index };
+      expect(props.setDragActiveState).toHaveBeenCalledWith(payload);
     });
   });
 });

--- a/src/components/__tests__/LayoutManager.test.js
+++ b/src/components/__tests__/LayoutManager.test.js
@@ -26,6 +26,9 @@ describe('LayoutManager', () => {
       createCellGroup: jest.fn(),
       reserved: [],
       active: {},
+      navigation: {
+        navigate: jest.fn(),
+      },
       ...merge,
     };
 
@@ -245,6 +248,7 @@ describe('LayoutManager', () => {
 
       onRelease();
       expect(props.createCellGroup).toHaveBeenCalledWith(props.active);
+      expect(props.navigation.navigate).toHaveBeenCalledWith('LayoutConfig');
     });
   });
 

--- a/src/components/__tests__/LayoutManager.test.js
+++ b/src/components/__tests__/LayoutManager.test.js
@@ -200,6 +200,17 @@ describe('LayoutManager', () => {
       expect(props.setDragActiveState).not.toHaveBeenCalled();
     });
 
+    it('does not set active state if already active', () => {
+      const { props, onMove } = gesture({
+        selected: '6:1',
+      });
+
+      const event = { x0: 1, y0: 490, dx: 0, dy: 0 };
+      onMove(null, event);
+
+      expect(props.setGroupHover).not.toHaveBeenCalled();
+    });
+
     it('edits the cell group on press', () => {
       const { props, onRelease } = gesture({
         selected: '1:1',

--- a/src/components/__tests__/LayoutManager.test.js
+++ b/src/components/__tests__/LayoutManager.test.js
@@ -1,12 +1,26 @@
+import { Dimensions } from 'react-native';
+import update from 'immutability-helper';
 import { shallow } from 'enzyme';
 import React from 'react';
+import R from 'ramda';
 
-import { LayoutManager } from '../LayoutManager';
-import Layout from '../Layout';
+import { LayoutManager, mapStateToProps } from '../LayoutManager';
+import LayoutSelection from '../LayoutSelection';
+import Layout, { fmtIndex } from '../Layout';
+import LayoutOption from '../LayoutOption';
+
+jest.spyOn(Dimensions, 'get');
 
 describe('LayoutManager', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   const setup = merge => {
     const props = {
+      setDragActiveState: jest.fn(),
+      createCellGroup: jest.fn(),
+      active: {},
       navigation: {
         navigate: jest.fn(),
       },
@@ -14,9 +28,12 @@ describe('LayoutManager', () => {
     };
 
     const output = shallow(<LayoutManager {...props} />);
-    const dimensions = { top: 0, left: 0, height: 560, width: 300 };
+    const dimensions = { top: 0, left: 0, height: 630, width: 360 };
     const event = { nativeEvent: { layout: dimensions } };
     output.simulate('layout', event);
+
+    // Hack: perfectly divisible. Avoids leftover height calculations.
+    Dimensions.get.mockReturnValue(dimensions);
 
     return {
       dimensions,
@@ -42,5 +59,174 @@ describe('LayoutManager', () => {
     const layout = output.find(Layout);
 
     expect(layout.prop('container')).toBe(dimensions);
+  });
+
+  it('shows options in empty spaces', () => {
+    const { output } = setup();
+    const layout = output.find(Layout);
+
+    expect(layout.prop('renderEmptySpace')).toBe(LayoutOption);
+  });
+
+  it('shows group slots in reserved spaces', () => {
+    const { output } = setup();
+    const layout = output.find(Layout);
+
+    expect(layout.prop('renderReservedSpace')).toBe(LayoutSelection);
+  });
+
+  describe('gesture', () => {
+    const gesture = merge => {
+      const result = setup(merge);
+
+      const { onCellLayout } = result.output.find(Layout).props();
+      const indexLayouts = R.map(R.apply(onCellLayout));
+      const height = 97.33;
+      const width = 90;
+
+      // Real layout data.
+      R.pipe(R.toPairs, indexLayouts)({
+        '1:1': { height, width, y: 0, x: 0 },
+        '1:2': { height, width, y: 0, x: 90 },
+        '1:3': { height, width, y: 0, x: 180 },
+        '1:4': { height, width, y: 0, x: 270 },
+        '2:1': { height, width, y: 97.33, x: 0 },
+        '2:2': { height, width, y: 97.33, x: 90 },
+        '2:3': { height, width, y: 97.33, x: 180 },
+        '2:4': { height, width, y: 97.33, x: 270 },
+        '3:1': { height, width, y: 194.67, x: 0 },
+        '3:2': { height, width, y: 194.67, x: 90 },
+        '3:3': { height, width, y: 194.67, x: 180 },
+        '3:4': { height, width, y: 194.67, x: 270 },
+        '4:1': { height, width, y: 292, x: 0 },
+        '4:2': { height, width, y: 292, x: 90 },
+        '4:3': { height, width, y: 292, x: 180 },
+        '4:4': { height, width, y: 292, x: 270 },
+        '5:1': { height, width, y: 389.33, x: 0 },
+        '5:2': { height, width, y: 389.33, x: 90 },
+        '5:3': { height, width, y: 389.33, x: 180 },
+        '5:4': { height, width, y: 389.33, x: 270 },
+        '6:1': { height, width, y: 486.67, x: 0 },
+        '6:2': { height, width, y: 486.67, x: 90 },
+        '6:3': { height, width, y: 486.67, x: 180 },
+        '6:4': { height, width, y: 486.67, x: 270 },
+      });
+
+      const {
+        onPanResponderMove,
+        onPanResponderRelease,
+      } = result.output.instance();
+
+      return {
+        ...result,
+        onMove: onPanResponderMove,
+        onRelease: onPanResponderRelease,
+      };
+    };
+
+    it('marks cells as active when dragging immediately over them', () => {
+      const { props, onMove } = gesture();
+
+      const event = { x0: 1, y0: 1, dx: 4, dy: 4 };
+      onMove(null, event);
+
+      const index = fmtIndex(1, 1);
+      const payload = { [index]: true };
+      expect(props.setDragActiveState).toHaveBeenCalledWith(payload);
+    });
+
+    it('does not mark cells as active while already active', () => {
+      const { props, onMove } = gesture({
+        active: { [fmtIndex(1, 1)]: true },
+      });
+
+      const event = { x0: 1, y0: 1, dx: 1, dy: 1 };
+      onMove(null, event);
+
+      expect(props.setDragActiveState).not.toHaveBeenCalled();
+    });
+
+    it('marks cells as selected if intersection exists', () => {
+      const { props, dimensions, onMove } = gesture();
+
+      // The whole top row.
+      const event = {
+        y0: 1,
+        dy: 1,
+        x0: dimensions.width - 1,
+        dx: -dimensions.width + 1,
+      };
+
+      onMove(null, event);
+
+      expect(props.setDragActiveState).toHaveBeenCalledWith({
+        [fmtIndex(1, 1)]: true,
+        [fmtIndex(1, 2)]: true,
+        [fmtIndex(1, 3)]: true,
+        [fmtIndex(1, 4)]: true,
+      });
+    });
+
+    it('marks cells inactive when drawn away', () => {
+      const { props, onMove } = gesture({
+        active: { '4:1': true },
+      });
+
+      const event = { y0: 1, dy: 1, x0: 1, dx: 1 };
+      onMove(null, event);
+
+      expect(props.setDragActiveState).toHaveBeenCalledWith({
+        [fmtIndex(4, 1)]: false,
+        [fmtIndex(1, 1)]: true,
+      });
+    });
+
+    it('shows a setup page after selecting cells', () => {
+      const { props, onRelease } = gesture({
+        active: { '1:1': true },
+      });
+
+      onRelease();
+      expect(props.createCellGroup).toHaveBeenCalledWith(props.active);
+      expect(props.navigation.navigate).toHaveBeenCalledWith('LayoutConfig');
+    });
+
+    it('does not trigger a config if nothing is selected', () => {
+      const { props, onRelease } = gesture({
+        active: {},
+      });
+
+      onRelease();
+
+      expect(props.createCellGroup).not.toHaveBeenCalled();
+      expect(props.navigation.navigate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('mapStateToProps', () => {
+    const select = (updates = {}) => {
+      const defaultState = {
+        layout: {
+          active: {
+            '1:1': true,
+            '2:1': true,
+            '3:1': true,
+          },
+        },
+      };
+
+      const state = update(defaultState, updates);
+
+      return {
+        props: mapStateToProps(state),
+        state,
+      };
+    };
+
+    it('gets the set of active cells', () => {
+      const { props, state } = select();
+
+      expect(props.active).toEqual(state.layout.active);
+    });
   });
 });

--- a/src/components/__tests__/LayoutOption.test.js
+++ b/src/components/__tests__/LayoutOption.test.js
@@ -1,11 +1,13 @@
 import { shallow } from 'enzyme';
 import React from 'react';
 
-import { LayoutOption } from '../LayoutOption';
+import { LayoutOption, styles } from '../LayoutOption';
 
 describe('LayoutOption', () => {
   const setup = merge => {
     const props = {
+      onLayout: jest.fn(),
+      active: false,
       height: 95,
       width: 90,
       left: 180,
@@ -30,5 +32,17 @@ describe('LayoutOption', () => {
     // This test assumes the last style value is inline.
     const [inline] = output.prop('style').slice(-1);
     expect(inline).toMatchObject({ height, width, left, top });
+  });
+
+  it('applies the active class when active', () => {
+    const { output } = setup({ active: true });
+
+    expect(output.prop('style')).toContain(styles.selected);
+  });
+
+  it('passes through onLayout', () => {
+    const { output, props } = setup();
+
+    expect(output.prop('onLayout')).toBe(props.onLayout);
   });
 });

--- a/src/components/__tests__/LayoutOption.test.js
+++ b/src/components/__tests__/LayoutOption.test.js
@@ -1,0 +1,34 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import { LayoutOption } from '../LayoutOption';
+
+describe('LayoutOption', () => {
+  const setup = merge => {
+    const props = {
+      height: 95,
+      width: 90,
+      left: 180,
+      top: 90,
+      ...merge,
+    };
+
+    return {
+      output: shallow(<LayoutOption {...props} />),
+      props,
+    };
+  };
+
+  it('renders', () => {
+    setup();
+  });
+
+  it('uses the given dimensions', () => {
+    const { output, props } = setup();
+    const { height, width, left, top } = props;
+
+    // This test assumes the last style value is inline.
+    const [inline] = output.prop('style').slice(-1);
+    expect(inline).toMatchObject({ height, width, left, top });
+  });
+});

--- a/src/components/__tests__/LayoutOption.test.js
+++ b/src/components/__tests__/LayoutOption.test.js
@@ -1,7 +1,7 @@
 import { shallow } from 'enzyme';
 import React from 'react';
 
-import { LayoutOption, styles } from '../LayoutOption';
+import { LayoutOption } from '../LayoutOption';
 
 describe('LayoutOption', () => {
   const setup = merge => {
@@ -29,15 +29,14 @@ describe('LayoutOption', () => {
     const { output, props } = setup();
     const { height, width, left, top } = props;
 
-    // This test assumes the last style value is inline.
-    const [inline] = output.prop('style').slice(-1);
+    const inline = output.prop('style');
     expect(inline).toMatchObject({ height, width, left, top });
   });
 
   it('applies the active class when active', () => {
-    const { output } = setup({ active: true });
+    const { output, props } = setup({ active: true });
 
-    expect(output.prop('style')).toContain(styles.selected);
+    expect(output.prop('active')).toBe(props.active);
   });
 
   it('passes through onLayout', () => {

--- a/src/components/__tests__/LayoutSelection.test.js
+++ b/src/components/__tests__/LayoutSelection.test.js
@@ -1,0 +1,34 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import R from 'ramda';
+
+import { LayoutSelection } from '../LayoutSelection';
+
+describe('LayoutSelection', () => {
+  const setup = merge => {
+    const props = {
+      height: 16,
+      width: 8,
+      left: 4,
+      top: 2,
+      ...merge,
+    };
+
+    return {
+      output: shallow(<LayoutSelection {...props} />),
+      props,
+    };
+  };
+
+  it('renders', () => {
+    setup();
+  });
+
+  it('uses the given coordinates', () => {
+    const { output, props } = setup();
+    const [inline] = output.prop('style').slice(-1);
+    const dimensions = R.pick(['top', 'left', 'width', 'height'], props);
+
+    expect(inline).toMatchObject(dimensions);
+  });
+});

--- a/src/components/__tests__/LayoutSelection.test.js
+++ b/src/components/__tests__/LayoutSelection.test.js
@@ -7,6 +7,7 @@ import { LayoutSelection } from '../LayoutSelection';
 describe('LayoutSelection', () => {
   const setup = merge => {
     const props = {
+      onLayout: jest.fn(),
       height: 16,
       width: 8,
       left: 4,
@@ -30,5 +31,11 @@ describe('LayoutSelection', () => {
     const dimensions = R.pick(['top', 'left', 'width', 'height'], props);
 
     expect(inline).toMatchObject(dimensions);
+  });
+
+  it('passes through onLayout', () => {
+    const { output, props } = setup();
+
+    expect(output.prop('onLayout')).toBe(props.onLayout);
   });
 });

--- a/src/components/__tests__/LayoutSelection.test.js
+++ b/src/components/__tests__/LayoutSelection.test.js
@@ -1,13 +1,17 @@
+import { Text, View } from 'react-native';
+import update from 'immutability-helper';
 import { shallow } from 'enzyme';
 import React from 'react';
 import R from 'ramda';
 
-import { LayoutSelection } from '../LayoutSelection';
+import { LayoutSelection, mapStateToProps, styles } from '../LayoutSelection';
 
 describe('LayoutSelection', () => {
   const setup = merge => {
     const props = {
+      groupTitle: 'Living Room',
       onLayout: jest.fn(),
+      blockWidth: 2,
       height: 16,
       width: 8,
       left: 4,
@@ -27,7 +31,8 @@ describe('LayoutSelection', () => {
 
   it('uses the given coordinates', () => {
     const { output, props } = setup();
-    const [inline] = output.prop('style').slice(-1);
+    const container = output.find(View);
+    const inline = R.last(container.prop('style'));
     const dimensions = R.pick(['top', 'left', 'width', 'height'], props);
 
     expect(inline).toMatchObject(dimensions);
@@ -35,7 +40,84 @@ describe('LayoutSelection', () => {
 
   it('passes through onLayout', () => {
     const { output, props } = setup();
+    const container = output.find(View);
 
-    expect(output.prop('onLayout')).toBe(props.onLayout);
+    expect(container.prop('onLayout')).toBe(props.onLayout);
+  });
+
+  it('shows the group name', () => {
+    const { output, props } = setup();
+    const text = output.find(Text);
+
+    expect(text.prop('children')).toBe(props.groupTitle);
+  });
+
+  it('shows a smaller group name when constrained', () => {
+    const { output } = setup({ blockWidth: 1 });
+    const text = output.find(Text);
+
+    expect(text.prop('style')).toContain(styles.smallTitle);
+  });
+
+  it('shows a large group name when possible', () => {
+    const { output } = setup({ blockWidth: 2 });
+    const text = output.find(Text);
+
+    expect(text.prop('style')).not.toContain(styles.smallTitle);
+  });
+
+  describe('mapStateToProps', () => {
+    const select = (updates = {}, ownProps = { id: '2:4' }) => {
+      const groupId = '6';
+      const defaultState = {
+        layout: {
+          reserved: {
+            [ownProps.id]: {
+              group: groupId,
+              height: 2,
+              width: 1,
+              x: 2,
+              y: 4,
+            },
+          },
+        },
+        groups: {
+          [groupId]: {
+            name: 'Group name',
+          },
+        },
+      };
+
+      const state = update(defaultState, updates);
+
+      return {
+        props: mapStateToProps(state, ownProps),
+        ownProps,
+        groupId,
+        state,
+      };
+    };
+
+    it('works when nothing is defined', () => {
+      const { props } = select({
+        layout: { $set: null },
+        groups: { $set: null },
+      });
+
+      expect(props).toEqual(expect.any(Object));
+    });
+
+    it('fetches the group name', () => {
+      const { props, state, groupId } = select();
+
+      expect(props.groupTitle).toBe(state.groups[groupId].name);
+    });
+
+    it('fetches the layout width', () => {
+      const { props, state, ownProps } = select();
+
+      const expected = state.layout.reserved[ownProps.id].width;
+      expect(props.blockWidth).toBe(expected);
+    });
   });
 });

--- a/src/components/__tests__/LayoutSelection.test.js
+++ b/src/components/__tests__/LayoutSelection.test.js
@@ -1,10 +1,14 @@
-import { Text, View } from 'react-native';
 import update from 'immutability-helper';
 import { shallow } from 'enzyme';
 import React from 'react';
 import R from 'ramda';
 
-import { LayoutSelection, mapStateToProps, styles } from '../LayoutSelection';
+import {
+  LayoutSelection,
+  mapStateToProps,
+  Container,
+  Title,
+} from '../LayoutSelection';
 
 describe('LayoutSelection', () => {
   const setup = merge => {
@@ -31,8 +35,8 @@ describe('LayoutSelection', () => {
 
   it('uses the given coordinates', () => {
     const { output, props } = setup();
-    const container = output.find(View);
-    const inline = R.last(container.prop('style'));
+    const container = output.find(Container);
+    const inline = container.prop('style');
     const dimensions = R.pick(['top', 'left', 'width', 'height'], props);
 
     expect(inline).toMatchObject(dimensions);
@@ -40,30 +44,30 @@ describe('LayoutSelection', () => {
 
   it('passes through onLayout', () => {
     const { output, props } = setup();
-    const container = output.find(View);
+    const container = output.find(Container);
 
     expect(container.prop('onLayout')).toBe(props.onLayout);
   });
 
   it('shows the group name', () => {
     const { output, props } = setup();
-    const text = output.find(Text);
+    const title = output.find(Title);
 
-    expect(text.prop('children')).toBe(props.groupTitle);
+    expect(title.prop('children')).toBe(props.groupTitle);
   });
 
   it('shows a smaller group name when constrained', () => {
     const { output } = setup({ blockWidth: 1 });
-    const text = output.find(Text);
+    const title = output.find(Title);
 
-    expect(text.prop('style')).toContain(styles.smallTitle);
+    expect(title.prop('small')).toBe(true);
   });
 
   it('shows a large group name when possible', () => {
     const { output } = setup({ blockWidth: 2 });
-    const text = output.find(Text);
+    const title = output.find(Title);
 
-    expect(text.prop('style')).not.toContain(styles.smallTitle);
+    expect(title.prop('small')).toBe(false);
   });
 
   describe('mapStateToProps', () => {

--- a/src/components/__tests__/Loading.test.js
+++ b/src/components/__tests__/Loading.test.js
@@ -8,6 +8,7 @@ describe('Loading', () => {
   const setup = merge => {
     const props = {
       getServerUrl: jest.fn(() => Promise.resolve({})),
+      getLayouts: jest.fn(),
       navigation: {
         dispatch: jest.fn(),
       },
@@ -30,6 +31,12 @@ describe('Loading', () => {
     await output.instance().componentWillMount();
 
     expect(props.getServerUrl).toHaveBeenCalled();
+  });
+
+  it('fetches the layouts on mount', () => {
+    const { props } = setup();
+
+    expect(props.getLayouts).toHaveBeenCalled();
   });
 
   it('shows the groups on success', async () => {

--- a/src/components/__tests__/Loading.test.js
+++ b/src/components/__tests__/Loading.test.js
@@ -1,0 +1,64 @@
+import { NavigationActions } from 'react-navigation';
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import { Loading } from '../Loading';
+
+describe('Loading', () => {
+  const setup = merge => {
+    const props = {
+      getServerUrl: jest.fn(() => Promise.resolve({})),
+      navigation: {
+        dispatch: jest.fn(),
+      },
+      ...merge,
+    };
+
+    return {
+      output: shallow(<Loading {...props} />),
+      props,
+    };
+  };
+
+  it('works', () => {
+    setup();
+  });
+
+  it('fetches the server URL on mount', async () => {
+    const { props, output } = setup();
+
+    await output.instance().componentWillMount();
+
+    expect(props.getServerUrl).toHaveBeenCalled();
+  });
+
+  it('shows the groups on success', async () => {
+    const { props, output } = setup({
+      getServerUrl: jest.fn(() =>
+        Promise.resolve({ payload: 'http://server/' }),
+      ),
+    });
+
+    await output.instance().componentWillMount();
+
+    expect(props.navigation.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actions: [NavigationActions.navigate({ routeName: 'Groups' })],
+      }),
+    );
+  });
+
+  it('shows the server setup page on failure', async () => {
+    const { props, output } = setup({
+      getServerUrl: jest.fn(() => Promise.resolve({ payload: null })),
+    });
+
+    await output.instance().componentWillMount();
+
+    expect(props.navigation.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actions: [NavigationActions.navigate({ routeName: 'ServerLink' })],
+      }),
+    );
+  });
+});

--- a/src/components/__tests__/ServerLink.test.js
+++ b/src/components/__tests__/ServerLink.test.js
@@ -1,9 +1,9 @@
-import { TextInput, Button } from 'react-native';
+import { Button } from 'react-native';
 import update from 'immutability-helper';
 import { shallow } from 'enzyme';
 import React from 'react';
 
-import { ServerLink, mapStateToProps } from '../ServerLink';
+import { ServerLink, UrlInput, mapStateToProps } from '../ServerLink';
 import { STATES } from '../../reducers/filament';
 import { error } from '../../constants/colors';
 
@@ -61,7 +61,7 @@ describe('ServerLink', () => {
 
   it('shows an input element', () => {
     const { output } = setup();
-    const text = output.find(TextInput);
+    const text = output.find(UrlInput);
 
     expect(text.exists()).toBe(true);
   });
@@ -69,7 +69,7 @@ describe('ServerLink', () => {
   it('updates the server URL on input', () => {
     const { output, props } = setup();
     const url = 'http://';
-    output.find(TextInput).simulate('changeText', url);
+    output.find(UrlInput).simulate('changeText', url);
 
     expect(props.updateServerUrl).toHaveBeenCalledWith(url);
   });
@@ -98,21 +98,21 @@ describe('ServerLink', () => {
 
   it('pings the server when the submit button is pressed', () => {
     const { output, props } = setup();
-    output.find(TextInput).simulate('submitEditing');
+    output.find(UrlInput).simulate('submitEditing');
 
     expect(props.pingServer).toHaveBeenCalledWith(props.serverUrl);
   });
 
   it('does not ping the server if the url is invalid', () => {
     const { output, props } = setup({ urlLooksValid: false });
-    output.find(TextInput).simulate('submitEditing');
+    output.find(UrlInput).simulate('submitEditing');
 
     expect(props.pingServer).not.toHaveBeenCalled();
   });
 
   it('disables submit while pinging', () => {
     const { output, props } = setup({ testingConnection: true });
-    output.find(TextInput).simulate('submitEditing');
+    output.find(UrlInput).simulate('submitEditing');
     const button = output.find(Button);
 
     expect(props.pingServer).not.toHaveBeenCalled();

--- a/src/constants/colors.js
+++ b/src/constants/colors.js
@@ -13,6 +13,7 @@ export const appBackground = palette.darkgray;
 export const groups = {
   divider: '#15181F',
   bg: '#1B2129',
+  selected: '#161C23',
 };
 
 groups.status = {

--- a/src/constants/colors.js
+++ b/src/constants/colors.js
@@ -11,6 +11,7 @@ export const text = palette.lightgray;
 export const appBackground = palette.darkgray;
 
 export const groups = {
+  radio: palette.red,
   divider: '#15181F',
   bg: '#1B2129',
   selected: '#161C23',

--- a/src/constants/colors.js
+++ b/src/constants/colors.js
@@ -16,6 +16,11 @@ export const groups = {
   selected: '#161C23',
 };
 
+export const navbar = {
+  text: '#AEB9C4',
+  bg: '#101319',
+};
+
 groups.status = {
   off: groups.divider,
   on: palette.yellow,

--- a/src/constants/colors.js
+++ b/src/constants/colors.js
@@ -17,12 +17,12 @@ export const groups = {
   selected: '#161C23',
 };
 
-export const navbar = {
-  text: '#AEB9C4',
-  bg: '#101319',
-};
-
 groups.status = {
   off: groups.divider,
   on: palette.yellow,
+};
+
+export const navbar = {
+  text: '#AEB9C4',
+  bg: '#101319',
 };

--- a/src/reducers/__tests__/layout.test.js
+++ b/src/reducers/__tests__/layout.test.js
@@ -125,7 +125,7 @@ describe('Layout', () => {
   });
 
   describe('deleteGrouping', () => {
-    it('does thigns', () => {
+    it('deletes the grouping', () => {
       const initial = {
         ...defaultState,
         cellGroup: { id: '1:1' },

--- a/src/reducers/__tests__/layout.test.js
+++ b/src/reducers/__tests__/layout.test.js
@@ -104,4 +104,21 @@ describe('Layout', () => {
       });
     });
   });
+
+  describe('setGroupHover', () => {
+    it('sets the group hover state', () => {
+      const id = '1:2';
+      const action = actions.setGroupHover(id);
+      const state = reducer(undefined, action);
+
+      expect(state.selectedGroup).toBe(id);
+    });
+
+    it('can unset the group hover state', () => {
+      const action = actions.setGroupHover(null);
+      const state = reducer(undefined, action);
+
+      expect(state.selectedGroup).toBe(null);
+    });
+  });
 });

--- a/src/reducers/__tests__/layout.test.js
+++ b/src/reducers/__tests__/layout.test.js
@@ -56,7 +56,7 @@ describe('Layout', () => {
       const state = reducer(undefined, action);
 
       expect(state.newCellGroup).toEqual({
-        active,
+        selected: active,
       });
     });
   });

--- a/src/reducers/__tests__/layout.test.js
+++ b/src/reducers/__tests__/layout.test.js
@@ -39,4 +39,25 @@ describe('Layout', () => {
       expect(state.active).toEqual({ '1:1': true, '1:3': true });
     });
   });
+
+  describe('createCellGroup', () => {
+    it('removes all active cells', () => {
+      const active = { '1:1': true, '1:2': true };
+      const initial = { ...defaultState, active };
+      const action = actions.createCellGroup(active);
+      const state = reducer(initial, action);
+
+      expect(state.active).toEqual({});
+    });
+
+    it('sets a flag', () => {
+      const active = { '1:1': true, '2:1': true };
+      const action = actions.createCellGroup(active);
+      const state = reducer(undefined, action);
+
+      expect(state.newCellGroup).toEqual({
+        active,
+      });
+    });
+  });
 });

--- a/src/reducers/__tests__/layout.test.js
+++ b/src/reducers/__tests__/layout.test.js
@@ -106,6 +106,24 @@ describe('Layout', () => {
     });
   });
 
+  describe('updateGrouping', () => {
+    it('updates the group state', () => {
+      const id = '1:1';
+      const initial = {
+        ...defaultState,
+        cellGroup: { groupId: '10', id },
+        reserved: {
+          [id]: { group: '5' },
+        },
+      };
+
+      const state = reducer(initial, actions.updateGrouping());
+
+      expect(state.cellGroup).toBe(null);
+      expect(state.reserved[id].group).toBe('10');
+    });
+  });
+
   describe('setGroupHover', () => {
     it('sets the group hover state', () => {
       const id = '1:2';
@@ -145,6 +163,7 @@ describe('Layout', () => {
         isNewGroup: false,
         selected: null,
         groupId: '5',
+        id: '1:1',
       });
     });
   });

--- a/src/reducers/__tests__/layout.test.js
+++ b/src/reducers/__tests__/layout.test.js
@@ -17,22 +17,22 @@ describe('Layout', () => {
       expect(state.active).toEqual({ '0:1': true });
     });
 
-    it('can mark indexes as inactive', () => {
+    it('removes old indices', () => {
       const index = '5:0';
       const initial = {
         ...defaultState,
         active: { [index]: true },
       };
 
-      const action = actions.setDragActiveState({ [index]: false });
+      const action = actions.setDragActiveState({ '5:1': true });
       const state = reducer(initial, action);
 
-      expect(state.active).toEqual({});
+      expect(state.active).toEqual({ '5:1': true });
     });
 
     it('can update many indexes simulaneously', () => {
       const initial = { ...defaultState, active: { '1:2': true } };
-      const payload = { '1:1': true, '1:2': false, '1:3': true };
+      const payload = { '1:1': true, '1:3': true };
       const action = actions.setDragActiveState(payload);
       const state = reducer(initial, action);
 

--- a/src/reducers/__tests__/layout.test.js
+++ b/src/reducers/__tests__/layout.test.js
@@ -94,12 +94,12 @@ describe('Layout', () => {
       const state = reducer(identified, actions.createGrouping());
 
       expect(state.reserved).toEqual({
-        '0:0': {
+        '1:1': {
           group: id,
           height: 2,
           width: 1,
-          x: 0,
-          y: 0,
+          x: 1,
+          y: 1,
         },
       });
     });

--- a/src/reducers/__tests__/layout.test.js
+++ b/src/reducers/__tests__/layout.test.js
@@ -55,7 +55,8 @@ describe('Layout', () => {
       const action = actions.createCellGroup(active);
       const state = reducer(undefined, action);
 
-      expect(state.newCellGroup).toMatchObject({
+      expect(state.cellGroup).toMatchObject({
+        isNewGroup: true,
         selected: active,
       });
     });
@@ -69,7 +70,7 @@ describe('Layout', () => {
       const action = actions.selectGroup(id);
       const state = reducer(initial, action);
 
-      expect(state.newCellGroup.groupId).toBe(id);
+      expect(state.cellGroup.groupId).toBe(id);
     });
   });
 
@@ -82,7 +83,7 @@ describe('Layout', () => {
       const cellGroupings = reducer(undefined, createCellGroup);
       const state = reducer(cellGroupings, done);
 
-      expect(state.newCellGroup).toBe(null);
+      expect(state.cellGroup).toBe(null);
     });
 
     it('adds a reserved slot', () => {
@@ -119,6 +120,32 @@ describe('Layout', () => {
       const state = reducer(undefined, action);
 
       expect(state.selectedGroup).toBe(null);
+    });
+  });
+
+  describe('editCellGroup', () => {
+    it('sets the group edit state', () => {
+      const initial = {
+        ...defaultState,
+        reserved: {
+          '1:1': {
+            group: '5',
+            height: 1,
+            width: 1,
+            x: 1,
+            y: 1,
+          },
+        },
+      };
+
+      const action = actions.editCellGroup('1:1');
+      const state = reducer(initial, action);
+
+      expect(state.cellGroup).toMatchObject({
+        isNewGroup: false,
+        selected: null,
+        groupId: '5',
+      });
     });
   });
 });

--- a/src/reducers/__tests__/layout.test.js
+++ b/src/reducers/__tests__/layout.test.js
@@ -124,6 +124,27 @@ describe('Layout', () => {
     });
   });
 
+  describe('deleteGrouping', () => {
+    it('does thigns', () => {
+      const initial = {
+        ...defaultState,
+        cellGroup: { id: '1:1' },
+        reserved: {
+          '1:1': {},
+          '1:2': {},
+        },
+      };
+
+      const action = actions.deleteGrouping();
+      const state = reducer(initial, action);
+
+      expect(state.cellGroup).toBe(null);
+      expect(state.reserved).toEqual({
+        '1:2': expect.anything(),
+      });
+    });
+  });
+
   describe('setGroupHover', () => {
     it('sets the group hover state', () => {
       const id = '1:2';
@@ -145,6 +166,7 @@ describe('Layout', () => {
     it('sets the group edit state', () => {
       const initial = {
         ...defaultState,
+        selectedGroup: '1:1',
         reserved: {
           '1:1': {
             group: '5',
@@ -159,6 +181,7 @@ describe('Layout', () => {
       const action = actions.editCellGroup('1:1');
       const state = reducer(initial, action);
 
+      expect(state.selectedGroup).toBe(null);
       expect(state.cellGroup).toMatchObject({
         isNewGroup: false,
         selected: null,

--- a/src/reducers/__tests__/layout.test.js
+++ b/src/reducers/__tests__/layout.test.js
@@ -55,8 +55,52 @@ describe('Layout', () => {
       const action = actions.createCellGroup(active);
       const state = reducer(undefined, action);
 
-      expect(state.newCellGroup).toEqual({
+      expect(state.newCellGroup).toMatchObject({
         selected: active,
+      });
+    });
+  });
+
+  describe('selectGroup', () => {
+    it('marks the group ID as selected', () => {
+      const id = '18';
+      const createCellGroup = actions.createCellGroup({});
+      const initial = reducer(undefined, createCellGroup);
+      const action = actions.selectGroup(id);
+      const state = reducer(initial, action);
+
+      expect(state.newCellGroup.groupId).toBe(id);
+    });
+  });
+
+  describe('createGrouping', () => {
+    it('removes intermediate grouping state', () => {
+      const selected = { '0:0': true };
+      const createCellGroup = actions.createCellGroup(selected);
+      const done = actions.createGrouping();
+
+      const cellGroupings = reducer(undefined, createCellGroup);
+      const state = reducer(cellGroupings, done);
+
+      expect(state.newCellGroup).toBe(null);
+    });
+
+    it('adds a reserved slot', () => {
+      const id = '8';
+      const selected = { '1:1': true, '1:2': true };
+      const create = actions.createCellGroup(selected);
+      const initial = reducer(undefined, create);
+      const identified = reducer(initial, actions.selectGroup(id));
+      const state = reducer(identified, actions.createGrouping());
+
+      expect(state.reserved).toEqual({
+        '0:0': {
+          group: id,
+          height: 2,
+          width: 1,
+          x: 0,
+          y: 0,
+        },
       });
     });
   });

--- a/src/reducers/__tests__/layout.test.js
+++ b/src/reducers/__tests__/layout.test.js
@@ -11,7 +11,7 @@ describe('Layout', () => {
 
   describe('setDragActiveState', () => {
     it('can mark indexes as active', () => {
-      const action = actions.setDragActiveState({ index: '0:1', active: true });
+      const action = actions.setDragActiveState({ '0:1': true });
       const state = reducer(undefined, action);
 
       expect(state.active).toEqual({ '0:1': true });
@@ -24,10 +24,19 @@ describe('Layout', () => {
         active: { [index]: true },
       };
 
-      const action = actions.setDragActiveState({ index, active: false });
+      const action = actions.setDragActiveState({ [index]: false });
       const state = reducer(initial, action);
 
       expect(state.active).toEqual({});
+    });
+
+    it('can update many indexes simulaneously', () => {
+      const initial = { ...defaultState, active: { '1:2': true } };
+      const payload = { '1:1': true, '1:2': false, '1:3': true };
+      const action = actions.setDragActiveState(payload);
+      const state = reducer(initial, action);
+
+      expect(state.active).toEqual({ '1:1': true, '1:3': true });
     });
   });
 });

--- a/src/reducers/__tests__/layout.test.js
+++ b/src/reducers/__tests__/layout.test.js
@@ -1,0 +1,33 @@
+import reducer, { defaultState } from '../layout';
+import * as actions from '../../actions/layout';
+
+describe('Layout', () => {
+  it('returns state when unrecognized actions pass through', () => {
+    const state = {};
+    const result = reducer(state, { type: 'who knows' });
+
+    expect(result).toBe(state);
+  });
+
+  describe('setDragActiveState', () => {
+    it('can mark indexes as active', () => {
+      const action = actions.setDragActiveState({ index: '0:1', active: true });
+      const state = reducer(undefined, action);
+
+      expect(state.active).toEqual({ '0:1': true });
+    });
+
+    it('can mark indexes as inactive', () => {
+      const index = '5:0';
+      const initial = {
+        ...defaultState,
+        active: { [index]: true },
+      };
+
+      const action = actions.setDragActiveState({ index, active: false });
+      const state = reducer(initial, action);
+
+      expect(state.active).toEqual({});
+    });
+  });
+});

--- a/src/reducers/__tests__/layout.test.js
+++ b/src/reducers/__tests__/layout.test.js
@@ -190,4 +190,25 @@ describe('Layout', () => {
       });
     });
   });
+
+  describe('getLayouts', () => {
+    it('imports the layouts', () => {
+      const payload = {
+        '1:1': { x: 1, y: 1, width: 1, height: 1, group: '1' },
+      };
+
+      const action = { type: String(actions.getLayouts), payload };
+      const state = reducer(undefined, action);
+
+      expect(state.reserved).toBe(payload);
+    });
+
+    it('ignores the action if no data was found', () => {
+      const action = { type: String(actions.getLayouts), payload: null };
+      const initial = reducer(undefined, { type: 'UNKNOWN_TYPE' });
+      const state = reducer(initial, action);
+
+      expect(state.reserved).toBe(initial.reserved);
+    });
+  });
 });

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -2,8 +2,10 @@ import { combineReducers } from 'redux';
 
 import filament from './filament';
 import groups from './groups';
+import layout from './layout';
 
 export default combineReducers({
   server: filament,
   groups,
+  layout,
 });

--- a/src/reducers/layout.js
+++ b/src/reducers/layout.js
@@ -51,6 +51,7 @@ export default handleActions(
             groupId: reserved.group,
             isNewGroup: false,
             selected: null,
+            id: payload,
           },
         },
       });
@@ -85,6 +86,19 @@ export default handleActions(
               x: Number(x),
               y: Number(y),
             },
+          },
+        },
+      });
+    },
+
+    [actions.updateGrouping]: state => {
+      const { id, groupId } = state.cellGroup;
+
+      return update(state, {
+        cellGroup: { $set: null },
+        reserved: {
+          [id]: {
+            $merge: { group: groupId },
           },
         },
       });

--- a/src/reducers/layout.js
+++ b/src/reducers/layout.js
@@ -1,0 +1,29 @@
+import { handleActions } from 'redux-actions';
+import update from 'immutability-helper';
+
+import * as actions from '../actions/layout';
+
+export const defaultState = {
+  active: {},
+};
+
+export default handleActions(
+  {
+    [actions.setDragActiveState]: (state, { payload }) => {
+      const { index, active } = payload;
+
+      if (active) {
+        return update(state, {
+          active: {
+            [index]: { $set: true },
+          },
+        });
+      }
+
+      return update(state, {
+        active: { $unset: [index] },
+      });
+    },
+  },
+  defaultState,
+);

--- a/src/reducers/layout.js
+++ b/src/reducers/layout.js
@@ -5,7 +5,8 @@ import R from 'ramda';
 import * as actions from '../actions/layout';
 
 export const defaultState = {
-  newCellGroup: null,
+  selectedGroup: null,
+  cellGroup: null,
   reserved: {},
   active: {},
 };
@@ -20,9 +21,10 @@ export default handleActions(
     [actions.createCellGroup]: (state, { payload }) =>
       update(state, {
         active: { $set: {} },
-        newCellGroup: {
+        cellGroup: {
           $set: {
             selected: payload,
+            isNewGroup: true,
             groupId: null,
           },
         },
@@ -30,7 +32,7 @@ export default handleActions(
 
     [actions.selectGroup]: (state, { payload }) =>
       update(state, {
-        newCellGroup: {
+        cellGroup: {
           groupId: { $set: payload },
         },
       }),
@@ -40,8 +42,22 @@ export default handleActions(
         selectedGroup: { $set: payload },
       }),
 
+    [actions.editCellGroup]: (state, { payload }) => {
+      const reserved = state.reserved[payload];
+
+      return update(state, {
+        cellGroup: {
+          $set: {
+            groupId: reserved.group,
+            isNewGroup: false,
+            selected: null,
+          },
+        },
+      });
+    },
+
     [actions.createGrouping]: state => {
-      const { selected, groupId } = state.newCellGroup;
+      const { selected, groupId } = state.cellGroup;
 
       const fmt = (x, y) => `${x}:${y}`;
       const parse = index => index.split(':');
@@ -59,7 +75,7 @@ export default handleActions(
       const ys = new Set(selectedCells.map(R.prop(1)));
 
       return update(state, {
-        newCellGroup: { $set: null },
+        cellGroup: { $set: null },
         reserved: {
           [fmt(x, y)]: {
             $set: {

--- a/src/reducers/layout.js
+++ b/src/reducers/layout.js
@@ -12,17 +12,10 @@ export const defaultState = {
 
 export default handleActions(
   {
-    [actions.setDragActiveState]: (state, { payload }) => {
-      const removed = R.keys(R.filter(R.equals(false), payload));
-      const added = R.filter(R.identity, payload);
-
-      return update(state, {
-        active: {
-          $unset: removed,
-          $merge: added,
-        },
-      });
-    },
+    [actions.setDragActiveState]: (state, { payload }) =>
+      update(state, {
+        active: { $set: payload },
+      }),
 
     [actions.createCellGroup]: (state, { payload }) =>
       update(state, {

--- a/src/reducers/layout.js
+++ b/src/reducers/layout.js
@@ -46,6 +46,7 @@ export default handleActions(
       const reserved = state.reserved[payload];
 
       return update(state, {
+        selectedGroup: { $set: null },
         cellGroup: {
           $set: {
             groupId: reserved.group,
@@ -103,6 +104,12 @@ export default handleActions(
         },
       });
     },
+
+    [actions.deleteGrouping]: state =>
+      update(state, {
+        reserved: { $unset: [state.cellGroup.id] },
+        cellGroup: { $set: null },
+      }),
   },
   defaultState,
 );

--- a/src/reducers/layout.js
+++ b/src/reducers/layout.js
@@ -50,7 +50,7 @@ export default handleActions(
       const selectedCells = R.keys(selected).map(parse);
 
       // Locate the top-left index.
-      const [col, row] = selectedCells.reduce((matching, pair) => {
+      const [x, y] = selectedCells.reduce((matching, pair) => {
         const [x, y] = pair;
         if (x <= matching[0] && y <= matching[1]) return pair;
 
@@ -59,8 +59,6 @@ export default handleActions(
 
       const xs = new Set(selectedCells.map(R.prop(0)));
       const ys = new Set(selectedCells.map(R.prop(1)));
-      const x = col - 1;
-      const y = row - 1;
 
       return update(state, {
         newCellGroup: { $set: null },

--- a/src/reducers/layout.js
+++ b/src/reducers/layout.js
@@ -5,13 +5,14 @@ import R from 'ramda';
 import * as actions from '../actions/layout';
 
 export const defaultState = {
+  newCellGroup: null,
   active: {},
 };
 
 export default handleActions(
   {
     [actions.setDragActiveState]: (state, { payload }) => {
-      const removed = R.keys(R.filter(R.not, payload));
+      const removed = R.keys(R.filter(R.equals(false), payload));
       const added = R.filter(R.identity, payload);
 
       return update(state, {
@@ -21,6 +22,16 @@ export default handleActions(
         },
       });
     },
+
+    [actions.createCellGroup]: (state, { payload }) =>
+      update(state, {
+        active: { $set: {} },
+        newCellGroup: {
+          $set: {
+            active: payload,
+          },
+        },
+      }),
   },
   defaultState,
 );

--- a/src/reducers/layout.js
+++ b/src/reducers/layout.js
@@ -28,7 +28,7 @@ export default handleActions(
         active: { $set: {} },
         newCellGroup: {
           $set: {
-            active: payload,
+            selected: payload,
           },
         },
       }),

--- a/src/reducers/layout.js
+++ b/src/reducers/layout.js
@@ -110,6 +110,14 @@ export default handleActions(
         reserved: { $unset: [state.cellGroup.id] },
         cellGroup: { $set: null },
       }),
+
+    [actions.getLayouts]: (state, { payload }) => {
+      if (!payload) return state;
+
+      return update(state, {
+        reserved: { $set: payload },
+      });
+    },
   },
   defaultState,
 );

--- a/src/reducers/layout.js
+++ b/src/reducers/layout.js
@@ -35,6 +35,11 @@ export default handleActions(
         },
       }),
 
+    [actions.setGroupHover]: (state, { payload }) =>
+      update(state, {
+        selectedGroup: { $set: payload },
+      }),
+
     [actions.createGrouping]: state => {
       const { selected, groupId } = state.newCellGroup;
 

--- a/src/reducers/layout.js
+++ b/src/reducers/layout.js
@@ -6,6 +6,7 @@ import * as actions from '../actions/layout';
 
 export const defaultState = {
   newCellGroup: null,
+  reserved: {},
   active: {},
 };
 
@@ -29,9 +30,53 @@ export default handleActions(
         newCellGroup: {
           $set: {
             selected: payload,
+            groupId: null,
           },
         },
       }),
+
+    [actions.selectGroup]: (state, { payload }) =>
+      update(state, {
+        newCellGroup: {
+          groupId: { $set: payload },
+        },
+      }),
+
+    [actions.createGrouping]: state => {
+      const { selected, groupId } = state.newCellGroup;
+
+      const fmt = (x, y) => `${x}:${y}`;
+      const parse = index => index.split(':');
+      const selectedCells = R.keys(selected).map(parse);
+
+      // Locate the top-left index.
+      const [col, row] = selectedCells.reduce((matching, pair) => {
+        const [x, y] = pair;
+        if (x <= matching[0] && y <= matching[1]) return pair;
+
+        return matching;
+      });
+
+      const xs = new Set(selectedCells.map(R.prop(0)));
+      const ys = new Set(selectedCells.map(R.prop(1)));
+      const x = col - 1;
+      const y = row - 1;
+
+      return update(state, {
+        newCellGroup: { $set: null },
+        reserved: {
+          [fmt(x, y)]: {
+            $set: {
+              group: groupId,
+              height: ys.size,
+              width: xs.size,
+              x: Number(x),
+              y: Number(y),
+            },
+          },
+        },
+      });
+    },
   },
   defaultState,
 );

--- a/src/reducers/layout.js
+++ b/src/reducers/layout.js
@@ -1,5 +1,6 @@
 import { handleActions } from 'redux-actions';
 import update from 'immutability-helper';
+import R from 'ramda';
 
 import * as actions from '../actions/layout';
 
@@ -10,18 +11,14 @@ export const defaultState = {
 export default handleActions(
   {
     [actions.setDragActiveState]: (state, { payload }) => {
-      const { index, active } = payload;
-
-      if (active) {
-        return update(state, {
-          active: {
-            [index]: { $set: true },
-          },
-        });
-      }
+      const removed = R.keys(R.filter(R.not, payload));
+      const added = R.filter(R.identity, payload);
 
       return update(state, {
-        active: { $unset: [index] },
+        active: {
+          $unset: removed,
+          $merge: added,
+        },
       });
     },
   },

--- a/src/utils/__tests__/actions.test.js
+++ b/src/utils/__tests__/actions.test.js
@@ -1,5 +1,7 @@
-import { optimistic } from '../actions';
+import { createAction } from 'redux-actions';
 import R from 'ramda';
+
+import { optimistic, prefixActions } from '../actions';
 
 describe('Action util', () => {
   beforeEach(() => jest.clearAllMocks());
@@ -70,6 +72,42 @@ describe('Action util', () => {
           payload: retVal,
         }),
       );
+    });
+  });
+
+  describe('prefixActions', () => {
+    it('returns an action creator', () => {
+      const creator = prefixActions('BACON', createAction);
+      const action = creator('CONSUME')(5);
+
+      expect(action).toEqual({
+        type: 'BACON___CONSUME',
+        payload: 5,
+      });
+    });
+
+    it('passes all args to the creator factory', () => {
+      const mock = jest.fn();
+      const factory = prefixActions('SKYDIVE', mock);
+      factory('JUMP', 1, 2, 3);
+
+      expect(mock).toHaveBeenCalledWith(expect.any(String), 1, 2, 3);
+    });
+
+    it('throws if the prefix is omitted', () => {
+      const fail = () => prefixActions(undefined, jest.fn());
+
+      expect(fail).toThrow(/prefix/i);
+    });
+
+    it('defaults to using createAction', () => {
+      const creator = prefixActions('HYPNO_DRONES');
+      const action = creator('RELEASE')(Infinity);
+
+      expect(action).toEqual({
+        type: 'HYPNO_DRONES___RELEASE',
+        payload: Infinity,
+      });
     });
   });
 });

--- a/src/utils/__tests__/redux.test.js
+++ b/src/utils/__tests__/redux.test.js
@@ -1,0 +1,43 @@
+import { selector } from '../redux';
+import R from 'ramda';
+
+describe('Redux utils', () => {
+  describe('selector', () => {
+    it('is a function', () => {
+      expect(selector).toEqual(expect.any(Function));
+    });
+
+    it('returns a function', () => {
+      const result = selector({});
+
+      expect(result).toEqual(expect.any(Function));
+    });
+
+    it('invokes each subselector with the argument', () => {
+      const field = jest.fn();
+      const state = { state: true };
+      const props = { props: true };
+      const map = selector({ field });
+      map(state, props);
+
+      expect(field).toHaveBeenCalledWith(state, props);
+    });
+
+    it('computes the full state', () => {
+      const map = selector({
+        enabled: R.pipe(R.prop('enabled'), R.not),
+        count: R.path(['active', 'count']),
+      });
+
+      const result = map({
+        active: { count: 345876 },
+        enabled: false,
+      });
+
+      expect(result).toEqual({
+        enabled: true,
+        count: 345876,
+      });
+    });
+  });
+});

--- a/src/utils/actions.js
+++ b/src/utils/actions.js
@@ -1,4 +1,5 @@
 import { createAction } from 'redux-actions';
+import assert from 'minimalistic-assert';
 
 export const optimistic = (type, api) => {
   const optimisticType = `optimistically(${type})`;
@@ -22,4 +23,10 @@ export const optimistic = (type, api) => {
   };
 
   return creator;
+};
+
+export const prefixActions = (prefix, factory = createAction) => {
+  assert(typeof prefix === 'string', 'The prefix is required.');
+
+  return (type, ...args) => factory(`${prefix}___${type}`, ...args);
 };

--- a/src/utils/redux.js
+++ b/src/utils/redux.js
@@ -1,0 +1,11 @@
+import R from 'ramda';
+
+export const selector = fields => {
+  const pairs = R.toPairs(fields);
+
+  return (state, props) =>
+    pairs.reduce((result, [prop, selector]) => {
+      const value = selector(state, props);
+      return R.assoc(prop, value, result);
+    }, {});
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -781,6 +781,13 @@ babel-plugin-transform-decorators-legacy@^1.3.4:
     babel-runtime "^6.2.0"
     babel-template "^6.3.0"
 
+babel-plugin-transform-define@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-define/-/babel-plugin-transform-define-1.3.0.tgz#94c5f9459c810c738cc7c50cbd44a31829d6f319"
+  dependencies:
+    lodash "4.17.4"
+    traverse "0.6.6"
+
 babel-plugin-transform-es2015-arrow-functions@^6.5.0, babel-plugin-transform-es2015-arrow-functions@^6.8.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz#452692cb711d5f79dc7f85e440ce41b9f244d221"
@@ -1495,6 +1502,10 @@ ci-info@^1.0.0:
 circular-json@^0.3.1:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.3.tgz#815c99ea84f6809529d2f45791bdf82711352d66"
+
+clamp@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/clamp/-/clamp-1.0.1.tgz#66a0e64011816e37196828fdc8c8c147312c8634"
 
 cli-cursor@^1.0.1, cli-cursor@^1.0.2:
   version "1.0.2"
@@ -3220,7 +3231,7 @@ hoek@4.x.x:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.0.tgz#72d9d0754f7fe25ca2d01ad8f8f9a9449a89526d"
 
-hoist-non-react-statics@^2.2.1:
+hoist-non-react-statics@^2.2.0, hoist-non-react-statics@^2.2.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz#343db84c6018c650778898240135a1420ee22ce0"
 
@@ -4473,13 +4484,13 @@ lodash.zipobject@^4.1.3:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/lodash.zipobject/-/lodash.zipobject-4.1.3.tgz#b399f5aba8ff62a746f6979bf20b214f964dbef8"
 
+lodash@4.17.4, lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.14.1, lodash@^4.15.0, lodash@^4.16.6, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.6.1:
+  version "4.17.4"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
+
 lodash@^3.5.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
-
-lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.14.1, lodash@^4.15.0, lodash@^4.16.6, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.6.1:
-  version "4.17.4"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
 lodash@~2.4.1:
   version "2.4.2"
@@ -5352,6 +5363,12 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
 
+path-to-regexp@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
+  dependencies:
+    isarray "0.0.1"
+
 path-type@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441"
@@ -5683,6 +5700,22 @@ react-native-branch@2.0.0-beta.3:
   version "2.0.0-beta.3"
   resolved "https://registry.yarnpkg.com/react-native-branch/-/react-native-branch-2.0.0-beta.3.tgz#2167af86bbc9f964bd45bd5f37684e5b54965e32"
 
+react-native-dismiss-keyboard@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/react-native-dismiss-keyboard/-/react-native-dismiss-keyboard-1.0.0.tgz#32886242b3f2317e121f3aeb9b0a585e2b879b49"
+
+react-native-drawer-layout-polyfill@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/react-native-drawer-layout-polyfill/-/react-native-drawer-layout-polyfill-1.3.2.tgz#192c84d7a5a6b8a6d2be2c7daa5e4164518d0cc7"
+  dependencies:
+    react-native-drawer-layout "1.3.2"
+
+react-native-drawer-layout@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/react-native-drawer-layout/-/react-native-drawer-layout-1.3.2.tgz#b9740d7663a1dc4f88a61b9c6d93d2d948ea426e"
+  dependencies:
+    react-native-dismiss-keyboard "1.0.0"
+
 react-native-gesture-handler@1.0.0-alpha.30:
   version "1.0.0-alpha.30"
   resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-1.0.0-alpha.30.tgz#7f79c2da5a59cc8ce20cf04c11360409a53bef59"
@@ -5725,6 +5758,12 @@ react-native-scripts@1.8.1:
   dependencies:
     color "^2.0.1"
     lodash "^4.16.6"
+
+react-native-tab-view@^0.0.74:
+  version "0.0.74"
+  resolved "https://registry.yarnpkg.com/react-native-tab-view/-/react-native-tab-view-0.0.74.tgz#62c0c882d9232b461ce181d440d683b4f99d1bd8"
+  dependencies:
+    prop-types "^15.6.0"
 
 react-native-vector-icons@4.4.2:
   version "4.4.2"
@@ -5791,6 +5830,18 @@ react-native@^0.51.0:
     xcode "^0.9.1"
     xmldoc "^0.4.0"
     yargs "^9.0.0"
+
+react-navigation@^1.0.0-beta.23:
+  version "1.0.0-beta.23"
+  resolved "https://registry.yarnpkg.com/react-navigation/-/react-navigation-1.0.0-beta.23.tgz#e666c4985e80d1ba39662838b78ad681c07cc187"
+  dependencies:
+    babel-plugin-transform-define "^1.3.0"
+    clamp "^1.0.1"
+    hoist-non-react-statics "^2.2.0"
+    path-to-regexp "^1.7.0"
+    prop-types "^15.5.10"
+    react-native-drawer-layout-polyfill "^1.3.2"
+    react-native-tab-view "^0.0.74"
 
 react-proxy@^1.1.7:
   version "1.1.8"
@@ -6934,6 +6985,10 @@ tr46@^1.0.0:
 tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+
+traverse@0.6.6:
+  version "0.6.6"
+  resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.6.6.tgz#cbdf560fd7b9af632502fed40f918c157ea97137"
 
 "traverse@>=0.3.0 <0.4":
   version "0.3.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1190,7 +1190,7 @@ base64-js@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.2.0.tgz#a39992d723584811982be5e290bb6a53d86700f1"
 
-base64-js@^1.1.2:
+base64-js@^1.0.2, base64-js@^1.1.2:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.2.1.tgz#a91947da1f4a516ea38e5b4ec0ec3773675e0886"
 
@@ -1362,6 +1362,13 @@ buffer-equal-constant-time@1.0.1:
 buffer-fill@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/buffer-fill/-/buffer-fill-0.1.0.tgz#ca9470e8d4d1b977fd7543f4e2ab6a7dc95101a8"
+
+buffer@^5.0.3:
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.0.8.tgz#84daa52e7cf2fa8ce4195bc5cf0f7809e0930b24"
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
 
 buffers@~0.1.1:
   version "0.1.1"
@@ -1841,6 +1848,10 @@ csrf@~3.0.0:
     tsscmp "1.0.5"
     uid-safe "2.1.4"
 
+css-color-keywords@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/css-color-keywords/-/css-color-keywords-1.0.0.tgz#fea2616dc676b2962686b3af8dbdbe180b244e05"
+
 css-select@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
@@ -1849,6 +1860,14 @@ css-select@~1.2.0:
     css-what "2.1"
     domutils "1.5.1"
     nth-check "~1.0.1"
+
+css-to-react-native@^2.0.3:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-2.0.4.tgz#cf4cc407558b3474d4ba8be1a2cd3b6ce713101b"
+  dependencies:
+    css-color-keywords "^1.0.0"
+    fbjs "^0.8.5"
+    postcss-value-parser "^3.3.0"
 
 css-what@2.1:
   version "2.1.0"
@@ -2670,7 +2689,7 @@ fbjs-scripts@^0.8.1:
     semver "^5.1.0"
     through2 "^2.0.0"
 
-fbjs@^0.8.14, fbjs@^0.8.16, fbjs@^0.8.4, fbjs@^0.8.9:
+fbjs@^0.8.14, fbjs@^0.8.16, fbjs@^0.8.4, fbjs@^0.8.5, fbjs@^0.8.9:
   version "0.8.16"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
   dependencies:
@@ -3231,6 +3250,10 @@ hoek@4.x.x:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.0.tgz#72d9d0754f7fe25ca2d01ad8f8f9a9449a89526d"
 
+hoist-non-react-statics@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz#aa448cf0986d55cc40773b17174b7dd066cb7cfb"
+
 hoist-non-react-statics@^2.2.0, hoist-non-react-statics@^2.2.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz#343db84c6018c650778898240135a1420ee22ce0"
@@ -3338,6 +3361,10 @@ iconv-lite@0.4.19, iconv-lite@^0.4.17, iconv-lite@^0.4.8, iconv-lite@~0.4.13:
 idx@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/idx/-/idx-2.2.0.tgz#8544749f9faba6409822b5d9488ba5bc77b8fbfe"
+
+ieee754@^1.1.4:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
 
 ignore@^3.3.3:
   version "3.3.7"
@@ -3588,6 +3615,12 @@ is-path-inside@^1.0.0:
   dependencies:
     path-is-inside "^1.0.1"
 
+is-plain-object@^2.0.1:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
+  dependencies:
+    isobject "^3.0.1"
+
 is-posix-bracket@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz#3334dc79774368e92f016e6fbc0a88f5cd6e6bc4"
@@ -3677,6 +3710,10 @@ isobject@^2.0.0:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-2.1.0.tgz#f065561096a3f1da2ef46272f815c840d87e0c89"
   dependencies:
     isarray "1.0.0"
+
+isobject@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
 
 isomorphic-fetch@^2.1.1:
   version "2.2.1"
@@ -5456,6 +5493,10 @@ pn@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.0.0.tgz#1cf5a30b0d806cd18f88fc41a6b5d4ad615b3ba9"
 
+postcss-value-parser@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz#87f38f9f18f774a4ab4c8a232f5c5ce8872a9d15"
+
 pouchdb-collections@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/pouchdb-collections/-/pouchdb-collections-1.0.1.tgz#fe63a17da977611abef7cb8026cb1a9553fd8359"
@@ -5520,7 +5561,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.0:
+prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.6.0:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
   dependencies:
@@ -6741,6 +6782,23 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
+styled-components@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-2.4.0.tgz#086d0fd483d54638837fca3ea546a030b94adf75"
+  dependencies:
+    buffer "^5.0.3"
+    css-to-react-native "^2.0.3"
+    fbjs "^0.8.9"
+    hoist-non-react-statics "^1.2.0"
+    is-plain-object "^2.0.1"
+    prop-types "^15.5.4"
+    stylis "^3.4.0"
+    supports-color "^3.2.3"
+
+stylis@^3.4.0:
+  version "3.4.8"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.4.8.tgz#94380babbcd4c75726215794ca985b38ec96d1a3"
+
 superagent-proxy@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/superagent-proxy/-/superagent-proxy-1.0.2.tgz#92d3660578f618ed43a82cf8cac799fe2938ba2d"
@@ -6771,7 +6829,7 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
-supports-color@^3.1.2:
+supports-color@^3.1.2, supports-color@^3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
   dependencies:


### PR DESCRIPTION
Okay, quite a few changes in this one! This adds a pretty sweet feature. Instead of listing every group on the bridge, you can configure what groups you see, where the are on the screen, and how they're sized. For example:

<img src="https://user-images.githubusercontent.com/10053423/34961885-74db4146-f9fe-11e7-8d0e-9534ff0f335a.png" height="350" />

Each grouping can be changed and deleted, and spaces can be left empty. This is what the edit screen looks like:

<img src="https://user-images.githubusercontent.com/10053423/34961948-d3bede34-f9fe-11e7-8789-7ae6b44033ed.png" height="350" />

Layout state is kept local on the device.